### PR TITLE
PoS model - token withdrawal function

### DIFF
--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -261,7 +261,7 @@ func withdraw(validator_address, delegator_address)
     //COMMENT: is the amount slashed here the same than the one slashed when evidence is found? This is an important point
     var amount_after_slashing = unbond.amount
     forall (slash in slashes[validator_address] s.t. start <= slash.epoch && slash.epoch <= end)
-      amount_after_slashing *= (10000 - slash.rate) / 10000)
+      amount_after_slashing *= unbond.amount * slash.rate
     balance[validator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond

--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -261,7 +261,7 @@ func withdraw(validator_address, delegator_address)
     //COMMENT: is the amount slashed here the same than the one slashed when evidence is found? This is an important point
     var amount_after_slashing = amount
     forall (slash in slashes[validator_address] s.t. start <= slash.epoch && slash.epoch <= end)
-      amount_after_slashing += unbond.amount * slash.rate
+      amount_after_slashing += amount * slash.rate
     balance[delegator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond

--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -261,7 +261,7 @@ func withdraw(validator_address, delegator_address)
     //COMMENT: is the amount slashed here the same than the one slashed when evidence is found? This is an important point
     var amount_after_slashing = unbond.amount
     forall (slash in slashes[validator_address] s.t. start <= slash.epoch && slash.epoch <= end)
-      amount_after_slashing *= unbond.amount * slash.rate
+      amount_after_slashing += unbond.amount * slash.rate
     balance[delegator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond

--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -259,7 +259,7 @@ func withdraw(validator_address, delegator_address)
   //substract any pending slash before withdrawing
   forall (<start,end,amount> in selfunbonds) do
     //COMMENT: is the amount slashed here the same than the one slashed when evidence is found? This is an important point
-    var amount_after_slashing = unbond.amount
+    var amount_after_slashing = amount
     forall (slash in slashes[validator_address] s.t. start <= slash.epoch && slash.epoch <= end)
       amount_after_slashing += unbond.amount * slash.rate
     balance[delegator_address] += amount_after_slashing

--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -262,7 +262,7 @@ func withdraw(validator_address, delegator_address)
     var amount_after_slashing = unbond.amount
     forall (slash in slashes[validator_address] s.t. start <= slash.epoch && slash.epoch <= end)
       amount_after_slashing *= unbond.amount * slash.rate
-    balance[validator_address] += amount_after_slashing
+    balance[delegator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond
     unbonds[delegator_address][validator_address].deltas[(start,end)] = 0


### PR DESCRIPTION
The first commit is as discussed. The second commit switches to use the delegator address rather than validator address as the target of balance credit from a withdrawal (for self-bonds, delegator address is the same as validator address, but for delegations we should use delegator address).