### PR TITLE
PoS model - remove pending

### DIFF
--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -34,7 +34,7 @@ type Slash struct {
   epoch Epoch
   validator Addr
   block_height int //not used
-  slash_type
+  slash_type {duplicate_vote, ligth_client_attack}
 }
 
 type WeightedValidator struct {

--- a/2022/Q2/artifacts/pos-model/PoS-model.md
+++ b/2022/Q2/artifacts/pos-model/PoS-model.md
@@ -8,7 +8,7 @@
 type Addr
 type Key
 type Epoch uint
-type VotingPower int
+type VotingPower uint
 
 type Validator struct {
   consensus_key map<Epoch, Key>
@@ -50,11 +50,13 @@ type ValidatorSet struct {
 
 ## Constants
 
+```go
 pipeline_length uint
 unbonding_length uint
 votes_per_token uint
 duplicate_vote_rate float
 ligth_client_attack_rate float
+```
 
 ## Variables
 


### PR DESCRIPTION
This PR:
- Removes pending state completely and adapt transactions consequently
- Changes is_validator function
- Defines slash_rate function
- Removes comments already addressed
- Fixes some minor typos

- [ ]  Safety checks on validators state is only done at the offset. We should check that this is OK. For instance, the is_validator function only checks that validator.state == candidate at cur_epoch+offset. 
- [ ] is_validator is only used in the bond function. Shall we use it elsewhere? unbond?
- [ ] we should think about the logic of slashing and the interplay between withdraw and new_evidence