### PR TITLE
Add epoched variables

### DIFF
--- a/2022/Q2/artifacts/pos-model/MC_Staking.tla
+++ b/2022/Q2/artifacts/pos-model/MC_Staking.tla
@@ -37,7 +37,7 @@ VARIABLES
     txCounter,
     \* A serial number used to identify epochs
     \* @type: Int;
-    epoch,  
+    epoch,
     \* Whether at least one transaction has failed
     \* @type: Bool;
     failed

--- a/2022/Q2/artifacts/pos-model/MC_Staking.tla
+++ b/2022/Q2/artifacts/pos-model/MC_Staking.tla
@@ -46,4 +46,8 @@ INSTANCE Staking
 BalanceAlwaysPositive == 
     \A user \in UserAddrs: balanceOf[user] >= 0
 
+\* takes forever to check this
+UserConstantAmount == 
+    \A user \in UserAddrs: balanceOf[user] + unbonded[user] + delegated[user] = INITIAL_SUPPLY
+
 ===============================================================================

--- a/2022/Q2/artifacts/pos-model/MC_Staking.tla
+++ b/2022/Q2/artifacts/pos-model/MC_Staking.tla
@@ -1,0 +1,49 @@
+--------------------------- MODULE MC_Staking ---------------------------------
+\* an instance for model checking Staking.tla with Apalache
+EXTENDS Sequences, Staking_typedefs
+
+\* Use the set of three addresses.
+UserAddrs == { "user2", "user3", "validator" }
+
+VARIABLES
+    \* Coin balance for every Cosmos account.
+    \*
+    \* @type: BALANCE;
+    balanceOf,
+    \* Balance of unbonded coins that cannot be used during the bonding period.
+    \*
+    \* @type: BALANCE;
+    unbonded,
+    \* Coins that are delegated to Validator.
+    \*
+    \* @type: BALANCE;
+    delegated
+
+\* Variables that model transactions, not the state machine.
+VARIABLES    
+    \* The last executed transaction.
+    \*
+    \* @type: TX;
+    lastTx,
+    \* A serial number to assign unique ids to transactions
+    \* @type: Int;
+    nextTxId,
+    \* Counts the transaactions executed within an epoch
+    \* @type: Int;
+    txCounter,
+    \* A serial number used to identify epochs
+    \* @type: Int;
+    epoch,
+    \* Whether at least one transaction has failed
+    \* @type: Bool;
+    failed
+
+\* instantiate the spec
+INSTANCE Staking
+
+\* invariants to check and break the system
+
+BalanceAlwaysPositive == 
+    \A user \in UserAddrs: balanceOf[user] >= 0
+
+===============================================================================

--- a/2022/Q2/artifacts/pos-model/MC_Staking.tla
+++ b/2022/Q2/artifacts/pos-model/MC_Staking.tla
@@ -5,6 +5,10 @@ EXTENDS Sequences, Staking_typedefs
 \* Use the set of three addresses.
 UserAddrs == { "user2", "user3", "validator" }
 
+PipelineLength == 6
+
+UnbondingLength == 2
+
 VARIABLES
     \* Coin balance for every Cosmos account.
     \*
@@ -12,11 +16,11 @@ VARIABLES
     balanceOf,
     \* Balance of unbonded coins that cannot be used during the bonding period.
     \*
-    \* @type: BALANCE;
+    \* @type: EPOCHED;
     unbonded,
     \* Coins that are delegated to Validator.
     \*
-    \* @type: BALANCE;
+    \* @type: EPOCHED;
     delegated
 
 \* Variables that model transactions, not the state machine.
@@ -28,12 +32,12 @@ VARIABLES
     \* A serial number to assign unique ids to transactions
     \* @type: Int;
     nextTxId,
-    \* Counts the transaactions executed within an epoch
+    \* Counts the transactions executed within an epoch
     \* @type: Int;
     txCounter,
     \* A serial number used to identify epochs
     \* @type: Int;
-    epoch,
+    epoch,  
     \* Whether at least one transaction has failed
     \* @type: Bool;
     failed
@@ -43,11 +47,19 @@ INSTANCE Staking
 
 \* invariants to check and break the system
 
+\* a counterexample to this invariant will produce ten transactions,
+NoTenTransactions ==
+    nextTxId < 10 \/ failed
+
+\* No withdrawing. Use it to produce a counterexample.
+NoWithdraw ==
+    lastTx.tag /= "withdraw"
+
 BalanceAlwaysPositive == 
     \A user \in UserAddrs: balanceOf[user] >= 0
 
 \* takes forever to check this
-UserConstantAmount == 
-    \A user \in UserAddrs: balanceOf[user] + unbonded[user] + delegated[user] = INITIAL_SUPPLY
+\*UserConstantAmount == 
+\*    \A user \in UserAddrs: balanceOf[user] + unbonded[user] + delegated[user] = INITIAL_SUPPLY
 
 ===============================================================================

--- a/2022/Q2/artifacts/pos-model/Staking.tla
+++ b/2022/Q2/artifacts/pos-model/Staking.tla
@@ -32,7 +32,7 @@ VARIABLES
     \* @type: BALANCE;
     delegated
 
-\* Variables that model transactions, not the state machine.
+\* Variables that model transactions, epochs and offsets, not the state machine.
 VARIABLES    
     \* The last executed transaction.
     \*
@@ -41,7 +41,7 @@ VARIABLES
     \* A serial number to assign unique ids to transactions
     \* @type: Int;
     nextTxId,
-    \* Counts the transaactions executed within an epoch
+    \* Counts the transactions executed within an epoch
     \* @type: Int;
     txCounter,
     \* A serial number used to identify epochs
@@ -68,7 +68,6 @@ Validator == "validator"
 
 \* Initialize the balances
 Init ==
-    \* user{1,2,3} have 1M Cosmos coins, the validator has 1M - stake
     /\ balanceOf = [ a \in UserAddrs |->
         IF a /= "validator"
         THEN INITIAL_SUPPLY
@@ -133,7 +132,7 @@ Unbond(sender, amount) ==
 Withdraw(sender) ==
     LET fail ==
         \/ sender = Validator
-        \/ unbonded[sender] > 0
+        \/ unbonded[sender] <= 0
     IN
     /\ lastTx' = [ id |-> nextTxId, tag |-> "withdraw", fail |-> fail,
                    sender |-> sender, toAddr |-> Validator, value |-> unbonded[sender] ]

--- a/2022/Q2/artifacts/pos-model/Staking.tla
+++ b/2022/Q2/artifacts/pos-model/Staking.tla
@@ -1,0 +1,179 @@
+------------------------- MODULE Staking ---------------------------------
+(*
+ * Modeling the Anoma's staking module.
+ * This is a very minimal spec that includes delegate, unbond and withdraw
+ *
+ * Simplifications:
+ *   - We assume only one validator to be delegated to.
+ *   - Rewards are not specified.
+ *   - Jailing is not specified.
+ *   - Slashing and evidence handling is not specified.
+ * 
+ * Manuel Bravo, 2022
+ *)
+EXTENDS Integers, Apalache, Staking_typedefs
+
+CONSTANTS
+    \* Set of all addresses on Cosmos.
+    \* @type: Set(ADDR);
+    UserAddrs
+
+VARIABLES
+    \* Coin balance for every Cosmos account.
+    \*
+    \* @type: BALANCE;
+    balanceOf,
+    \* Balance of unbonded coins that cannot be used during the bonding period.
+    \*
+    \* @type: BALANCE;
+    unbonded,
+    \* Coins that are delegated to Validator.
+    \*
+    \* @type: BALANCE;
+    delegated
+
+\* Variables that model transactions, not the state machine.
+VARIABLES    
+    \* The last executed transaction.
+    \*
+    \* @type: TX;
+    lastTx,
+    \* A serial number to assign unique ids to transactions
+    \* @type: Int;
+    nextTxId,
+    \* Counts the transaactions executed within an epoch
+    \* @type: Int;
+    txCounter,
+    \* A serial number used to identify epochs
+    \* @type: Int;
+    epoch,
+    \* Whether at least one transaction has failed
+    \* @type: Bool;
+    failed
+
+\* the maximum value in Cosmos
+MAX_UINT == 2^(256 - 60) - 1
+
+\* 1 billion coins in the initial supply
+INITIAL_SUPPLY == 10^(9+18)
+
+\* the number of coins the validator has staked
+INIT_VALIDATOR_STAKE == 1000000000000000000000
+
+\* tx per epoch
+TXS_PER_EPOCH == 10
+
+\* the validator account
+Validator == "validator"
+
+\* Initialize the balances
+Init ==
+    \* user{1,2,3} have 1M Cosmos coins, the validator has 1M - stake
+    /\ balanceOf = [ a \in UserAddrs |->
+        IF a /= "validator"
+        THEN INITIAL_SUPPLY
+        ELSE INITIAL_SUPPLY - INIT_VALIDATOR_STAKE
+       ]
+    /\ unbonded = [ a \in UserAddrs |-> 0 ]
+    /\ delegated = [
+        a \in UserAddrs |-> IF a /= "validator"
+        THEN 0
+        ELSE INIT_VALIDATOR_STAKE
+       ]
+    /\ nextTxId = 0
+    /\ epoch = 1
+    /\ txCounter = 0
+    /\ lastTx = [ id |-> 0, tag |-> "None", fail |-> FALSE ]
+    /\ failed = FALSE
+
+
+\* delegate `amount` coins to Validator
+Delegate(sender, amount) ==
+    LET fail ==
+        \/ amount < 0
+        \/ amount > balanceOf[sender]
+    IN
+    /\ lastTx' = [ id |-> nextTxId, tag |-> "delegate", fail |-> fail,
+                   sender |-> sender, toAddr |-> Validator, value |-> amount ]
+    /\ nextTxId' = nextTxId + 1
+    /\ failed' = (fail \/ failed)
+    /\  IF fail
+        THEN
+          UNCHANGED <<balanceOf, unbonded, delegated>>
+        ELSE
+          \* transaction succeeds
+          \* update the balance of 'sender'
+          /\ balanceOf' =
+                [ balanceOf EXCEPT ![sender] = @ - amount]
+          /\ delegated' = [ delegated EXCEPT ![sender] = @ + amount ]
+          /\ UNCHANGED unbonded
+
+
+\* unbond `amount` coins from Validator
+Unbond(sender, amount) ==
+    LET fail ==
+        \/ amount < 0
+        \/ sender = Validator
+        \/ amount > delegated[sender]
+    IN
+    /\ lastTx' = [ id |-> nextTxId, tag |-> "unbond", fail |-> fail,
+                   sender |-> sender, toAddr |-> Validator, value |-> amount ]
+    /\ nextTxId' = nextTxId + 1
+    /\ failed' = (fail \/ failed)
+    /\  IF fail
+        THEN
+          UNCHANGED <<balanceOf, unbonded, delegated>>
+        ELSE
+          \* transaction succeeds
+          /\ unbonded' = [ unbonded EXCEPT ![sender] = @ + amount ]
+          /\ delegated' = [ delegated EXCEPT ![sender] = @ - amount ]
+          /\ UNCHANGED  balanceOf
+
+\* withdraw unbonded coins
+Withdraw(sender) ==
+    LET fail ==
+        \/ sender = Validator
+        \/ unbonded[sender] > 0
+    IN
+    /\ lastTx' = [ id |-> nextTxId, tag |-> "withdraw", fail |-> fail,
+                   sender |-> sender, toAddr |-> Validator, value |-> unbonded[sender] ]
+    /\ nextTxId' = nextTxId + 1
+    /\ failed' = (fail \/ failed)
+    /\  IF fail
+        THEN
+          UNCHANGED <<balanceOf, unbonded, delegated>>
+        ELSE
+          \* transaction succeeds
+          /\ balanceOf' = [ balanceOf EXCEPT ![sender] = @ + unbonded[sender] ]
+          /\ unbonded' = [ unbonded EXCEPT ![sender] = 0 ]
+          /\ UNCHANGED  delegated
+
+AdvanceEpoch ==
+    /\  IF txCounter = TXS_PER_EPOCH
+        THEN
+          \* move to the next epoch
+          /\ epoch' = epoch + 1
+          /\ txCounter' = 0
+        ELSE
+          \* do not advance epoch
+          /\ txCounter' = txCounter + 1
+          /\ UNCHANGED  epoch
+
+\* The transition relation, which chooses one of the actions
+Next ==
+    \/ \E sender \in UserAddrs:
+       \E amount \in Int:
+        /\ amount <= MAX_UINT
+        /\ \/ Delegate(sender, amount)
+           \/ Unbond(sender, amount)
+           \/ Withdraw(sender)
+        /\ AdvanceEpoch
+
+\* The transition relation assuming that no failure occurs
+NextNoFail ==
+    Next /\ ~failed /\ ~failed'
+
+(* False invariants to debug the spec *)
+
+
+===============================================================================

--- a/2022/Q2/artifacts/pos-model/Staking.tla
+++ b/2022/Q2/artifacts/pos-model/Staking.tla
@@ -100,10 +100,7 @@ Delegate(sender, amount) ==
     IN
     /\ lastTx' = [ id |-> nextTxId, tag |-> "delegate", fail |-> fail,
                    sender |-> sender, toAddr |-> Validator, value |-> amount ]
-    /\ nextTxId' = nextTxId + 1
-    /\ txCounter' = txCounter + 1
     /\ failed' = (fail \/ failed)
-    /\ UNCHANGED epoch
     /\  IF fail
         THEN
           UNCHANGED <<balanceOf, unbonded, delegated>>
@@ -124,10 +121,7 @@ Unbond(sender, amount) ==
     IN
     /\ lastTx' = [ id |-> nextTxId, tag |-> "unbond", fail |-> fail,
                    sender |-> sender, toAddr |-> Validator, value |-> amount ]
-    /\ nextTxId' = nextTxId + 1
-    /\ txCounter' = txCounter + 1
     /\ failed' = (fail \/ failed)
-    /\ UNCHANGED epoch
     /\  IF fail
         THEN
           UNCHANGED <<balanceOf, unbonded, delegated>>
@@ -145,10 +139,7 @@ Withdraw(sender) ==
     IN
     /\ lastTx' = [ id |-> nextTxId, tag |-> "withdraw", fail |-> fail,
                    sender |-> sender, toAddr |-> Validator, value |-> unbonded[1, sender] ]
-    /\ nextTxId' = nextTxId + 1
-    /\ txCounter' = txCounter + 1
     /\ failed' = (fail \/ failed)
-    /\ UNCHANGED epoch
     /\  IF fail
         THEN
           UNCHANGED <<balanceOf, unbonded, delegated>>
@@ -161,6 +152,11 @@ Withdraw(sender) ==
                           ELSE unbonded[n, user]
                          ]
           /\ UNCHANGED  delegated
+
+Common ==
+    /\ nextTxId' = nextTxId + 1
+    /\ txCounter' = txCounter + 1
+    /\ UNCHANGED epoch
 
 ShiftEpochoedVariables ==
     /\ unbonded' = [ n \in 1..UnbondingLength, user \in UserAddrs |-> 
@@ -192,6 +188,7 @@ Next ==
         /\ \/ Delegate(sender, amount)
            \/ Unbond(sender, amount)
            \/ Withdraw(sender)
+        /\ Common
 
 \* The transition relation assuming that no failure occurs
 NextNoFail ==

--- a/2022/Q2/artifacts/pos-model/Staking_typedefs.tla
+++ b/2022/Q2/artifacts/pos-model/Staking_typedefs.tla
@@ -1,0 +1,33 @@
+---------------------- MODULE Staking_typedefs --------------------------------
+(*
+  Type definitions for the module Staking.
+
+  An account address, in our case, simply an uninterpreted string:
+  @typeAlias: ADDR = Str;
+
+  @typeAlias: BALANCE = ADDR -> Int;
+
+  A transaction (a la discriminated union but all fields are packed together):
+  @typeAlias: TX = [
+    tag: Str,
+    id: Int,
+    fail: Bool,
+    sender: ADDR,
+    toAddr: ADDR,
+    value: Int
+  ];
+
+  A state of the state machine:
+  @typeAlias: STATE = [
+    balanceOf: ADDR -> Int,
+    delegated: ADDR -> Int,
+    unbonded: ADDR -> Int,
+    lastTx: TX,
+    nextTxId: Int,
+    failed: Bool
+  ];
+
+  Below is a dummy definition to introduce the above type aliases.
+ *) 
+Staking_typedefs == TRUE
+===============================================================================

--- a/2022/Q2/artifacts/pos-model/Staking_typedefs.tla
+++ b/2022/Q2/artifacts/pos-model/Staking_typedefs.tla
@@ -7,6 +7,8 @@
 
   @typeAlias: BALANCE = ADDR -> Int;
 
+  @typeAlias: EPOCHED = <<Int, ADDR>> -> Int;
+
   A transaction (a la discriminated union but all fields are packed together):
   @typeAlias: TX = [
     tag: Str,
@@ -19,9 +21,9 @@
 
   A state of the state machine:
   @typeAlias: STATE = [
-    balanceOf: ADDR -> Int,
-    delegated: ADDR -> Int,
-    unbonded: ADDR -> Int,
+    balanceOf: BALANCE,
+    delegated: EPOCHED,
+    unbonded: EPOCHED,
     lastTx: TX,
     nextTxId: Int,
     failed: Bool


### PR DESCRIPTION
This PR adds epoched variables: `delegated` and `unbonded`. It also add a couple of invariants to generate counter-examples to the model:
- one that generates a trace of 10 transactions
- one that generated a trace that includes at least one `withdraw` transaction
