### PR TITLE
Reworked TLA+ model with cubic slashing

### DIFF
--- a/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
+++ b/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
@@ -8,11 +8,11 @@ UserAddrs == { "user2", "user3", "val1", "val2"}
 \* Set of two validators.
 ValidatorAddrs == {"val1", "val2"}
 
-PipelineLength == 2
+PipelineLength == 1
 
-UnbondingLength == 4
+UnbondingLength == 1
 
-TxsEpoch == 2
+TxsEpoch == 1
 
 VARIABLES
     \* Token balance for every account.
@@ -43,13 +43,9 @@ VARIABLES
     \*
     \* @type: ENQUEUEDSLASHES;
     enqueuedSlashes,
-    \* Set of jailed validators
-    \*
-    \* @type: Set(ADDR);
-    jailedValidators,
     \* Set of frozen validators
     \*
-    \* @type: Set(ADDR);
+    \* @type: FROZEN;
     frozenValidators
 
 \* Variables that model transactions, not the state machine.
@@ -93,9 +89,21 @@ NoFiveTransactions ==
 NoTenTransactions ==
     nextTxId < 10 \/ failed
 
+\* No successful withdrawing. Use it to produce a counterexample.
+NoSuccessfulWithdraw ==
+    LET Example ==
+        /\ lastTx.tag = "withdraw"
+        /\ lastTx.value > 0
+    IN
+    ~Example
+
 \* No withdrawing. Use it to produce a counterexample.
 NoWithdraw ==
     lastTx.tag /= "withdraw"
+
+\* No evidence. Use it to produce a counterexample.
+NoEvidence ==
+    lastTx.tag /= "evidence"
 
 \* From Chris
 \* Try to capture that for a group of validators with total voting power X at

--- a/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
+++ b/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
@@ -81,29 +81,30 @@ INSTANCE Staking
 
 \* invariants to check and break the system
 
-\* a counterexample to this invariant will produce five transactions,
-NoFiveTransactions ==
-    nextTxId < 5 \/ failed
-
-\* a counterexample to this invariant will produce ten transactions,
-NoTenTransactions ==
-    nextTxId < 10 \/ failed
-
 \* No successful withdrawing. Use it to produce a counterexample.
 NoSuccessfulWithdraw ==
     LET Example ==
         /\ lastTx.tag = "withdraw"
         /\ lastTx.value > 0
+        /\ ~lastTx.fail
     IN
     ~Example
 
 \* No withdrawing. Use it to produce a counterexample.
 NoWithdraw ==
-    lastTx.tag /= "withdraw"
+    LET Example ==
+        /\ lastTx.tag = "withdraw"
+        /\ ~lastTx.fail
+    IN
+    ~Example
 
 \* No evidence. Use it to produce a counterexample.
 NoEvidence ==
-    lastTx.tag /= "evidence"
+    LET Example ==
+        /\ lastTx.tag = "evidence"
+        /\ ~lastTx.fail
+    IN
+    ~Example
 
 \* From Chris
 \* Try to capture that for a group of validators with total voting power X at

--- a/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
+++ b/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
@@ -31,6 +31,10 @@ VARIABLES
     \*
     \* @type: TOTALDELTAS;
     totalDeltas,
+    \* Stake unbonded from a given validator at a given epoch.
+    \*
+    \* @type: TOTALUNBONDED;
+    totalUnbonded,
     \* PoS special account
     \*
     \* @type: Int;

--- a/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
+++ b/2022/Q3/artifacts/PoS-tla/MC_Staking.tla
@@ -10,27 +10,47 @@ ValidatorAddrs == {"val1", "val2"}
 
 PipelineLength == 2
 
-UnbondingLength == 6
+UnbondingLength == 4
 
-TxsEpoch == 4
+TxsEpoch == 2
 
 VARIABLES
-    \* Coin balance for every Cosmos account.
+    \* Token balance for every account.
     \*
     \* @type: BALANCE;
     balanceOf,
-    \* Balance of unbonded coins that cannot be used during the bonding period.
+    \* Balance of unbonded tokens that cannot be used during the bonding period.
     \*
     \* @type: UNBONDED;
     unbonded,
-    \* Coins that are delegated to Validator.
-    \*
-    \* @type: DELEGATED;
-    delegated,
-    \* Voting power of the validator.
+    \* Tokens that are delegated to a validator.
     \*
     \* @type: BONDED;
-    bonded
+    bonded,
+    \* Stake at a given validator.
+    \*
+    \* @type: TOTALDELTAS;
+    totalDeltas,
+    \* PoS special account
+    \*
+    \* @type: Int;
+    posAccount,
+    \* Slashes
+    \*
+    \* @type: SLASHES;
+    slashes,
+    \* Enqueued slashes
+    \*
+    \* @type: ENQUEUEDSLASHES;
+    enqueuedSlashes,
+    \* Set of jailed validators
+    \*
+    \* @type: Set(ADDR);
+    jailedValidators,
+    \* Set of frozen validators
+    \*
+    \* @type: Set(ADDR);
+    frozenValidators
 
 \* Variables that model transactions, not the state machine.
 VARIABLES    
@@ -47,6 +67,15 @@ VARIABLES
     \* A serial number used to identify epochs
     \* @type: Int;
     epoch,
+    \* A serial number used to identify bonds
+    \* @type: Int;
+    idBonds,
+    \* A serial number used to identify unbonds
+    \* @type: Int;
+    idUnbonds,
+    \* A serial number used to identify slashes
+    \* @type: Int;
+    idSlashes,
     \* Whether at least one transaction has failed
     \* @type: Bool;
     failed
@@ -56,6 +85,10 @@ INSTANCE Staking
 
 \* invariants to check and break the system
 
+\* a counterexample to this invariant will produce five transactions,
+NoFiveTransactions ==
+    nextTxId < 5 \/ failed
+
 \* a counterexample to this invariant will produce ten transactions,
 NoTenTransactions ==
     nextTxId < 10 \/ failed
@@ -64,14 +97,34 @@ NoTenTransactions ==
 NoWithdraw ==
     lastTx.tag /= "withdraw"
 
-ValDelegatedFold(set, val) == LET SumDelegated(p,q) == p + delegated[1, q, val]
+\* From Chris
+\* Try to capture that for a group of validators with total voting power X at
+\* a particular height, the proof-of-stake model provides the ability to look up
+\* bonds contributing to that voting power (for the unbonding period) and slash
+\* a proportional amount of stake to X (subject to limitations e.g. repeated infractions)
+
+\* Invariant #1
+\* the validator's voting power at a given epoch is equal to the total amount of
+\* tokens delegated to that validator
+
+(* ValDelegatedFold(set, val) == LET SumDelegated(p,q) == p + delegated[1, q, val]
                               IN ApaFoldSet( SumDelegated, 0, set )
 
 VotingpowerDelagations ==
     \A val \in ValidatorAddrs:
-    ValDelegatedFold(UserAddrs, val) = bonded[1, val]
+    ValDelegatedFold(UserAddrs, val) = bonded[1, val] *)
+
+\* Invariant #2
+\* the user balance is always greater or equal to zero
 
 BalanceAlwaysPositive == 
     \A user \in UserAddrs: balanceOf[user] >= 0
+
+
+\* Invariant #3
+\* posAccount is always greater or equal to zero
+
+PoSAccountAlwaysPositive == 
+    posAccount >= 0
 
 ===============================================================================

--- a/2022/Q3/artifacts/PoS-tla/Staking.tla
+++ b/2022/Q3/artifacts/PoS-tla/Staking.tla
@@ -179,13 +179,11 @@ ComputedUnbonds(setBonds, totalAmount, e) == LET
                                          F(record, bond) == 
                                          IF record.remaining > 0
                                          THEN 
-                                          IF record.remaining > bond.amount
-                                          THEN [ remaining |-> record.remaining - bond.amount,
-                                                 set |-> record.set \union {[id |-> record.id, amount |-> bond.amount, start |-> bond.epoch, end |-> e]},
-                                                 id |-> record.id + 1 ]
-                                          ELSE [ remaining |-> 0,
-                                                 set |-> record.set \union {[id |-> record.id, amount |-> record.remaining, start |-> bond.epoch, end |-> e]},
-                                                 id |-> record.id + 1 ]    
+                                          LET min == Min(record.remaining, bond.amount) 
+                                          IN
+                                          [ remaining |-> record.remaining - min,
+                                            set |-> record.set \union {[id |-> record.id, amount |-> min, start |-> bond.epoch, end |-> e]},
+                                            id |-> record.id + 1 ]   
                                          ELSE [ remaining |-> 0,
                                                 set |-> record.set,
                                                 id |-> record.id ]

--- a/2022/Q3/artifacts/PoS-tla/Staking.tla
+++ b/2022/Q3/artifacts/PoS-tla/Staking.tla
@@ -107,6 +107,16 @@ INIT_VALIDATOR_STAKE == 1000000000000000000000
 \* the amount of voting power per token
 SLASH_RATE == 1
 
+(*
+* Computes the Max of two numbers.
+*)
+Max(x, y) == IF x > y THEN x ELSE y
+
+(*
+* Computes the Min of two numbers.
+*)
+Min(x, y) == IF x < y THEN x ELSE y
+
 \* Initialize the balances
 Init ==
     /\ balanceOf = [ a \in UserAddrs |-> 
@@ -270,16 +280,6 @@ Evidence(e, validator) ==
     /\ lastTx' = [ id |-> nextTxId, tag |-> "evidence", fail |-> FALSE,
                    sender |-> validator, toAddr |-> validator, value |-> e ]
     /\ UNCHANGED <<epoch, balanceOf, posAccount, totalDeltas, bonded, idBonds, unbonded, idUnbonds, slashes, nextTxId, txCounter, failed>>
-
-(*
-* Computes the Max of two numbers.
-*)
-Max(x, y) == IF x > y THEN x ELSE y
-
-(*
-* Computes the Min of two numbers.
-*)
-Min(x, y) == IF x < y THEN x ELSE y
 
 (*
 * Actual function that requires Real numbers

--- a/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
+++ b/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
@@ -33,6 +33,7 @@
 
   A state of the state machine:
   @typeAlias: STATE = [
+    lastTx: TX,
     balanceOf: BALANCE,
     totalDeltas: TOTALDELTAS,
     totalUnbonded: TOTALUNBONDED,
@@ -40,7 +41,6 @@
     bonded: BONDED,
     slashes: SLASHES,
     enqueuedSlashes: ENQUEUEDSLASHES,
-    lastTx: TX,
     nextTxId: Int,
     failed: Bool
   ];

--- a/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
+++ b/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
@@ -7,11 +7,15 @@
 
   @typeAlias: BALANCE = ADDR -> Int;
 
-  @typeAlias: UNBONDED = <<Int, ADDR>> -> Int;
+  @typeAlias: UNBONDED = <<ADDR, ADDR>> -> Set(UNBOND);
 
-  @typeAlias: BONDED = <<Int, ADDR>> -> Int;
+  @typeAlias: BONDED = <<ADDR, ADDR>> -> Set(BOND);
 
-  @typeAlias: DELEGATED = <<Int, ADDR, ADDR>> -> Int;
+  @typeAlias: TOTALDELTAS = <<Int, ADDR>> -> Int;
+
+  @typeAlias: SLASHES = ADDR -> Set(SLASH);
+
+  @typeAlias: ENQUEUEDSLASHES = <<Int, ADDR>> -> Set(SLASH);
 
   A transaction (a la discriminated union but all fields are packed together):
   @typeAlias: TX = [
@@ -26,12 +30,35 @@
   A state of the state machine:
   @typeAlias: STATE = [
     balanceOf: BALANCE,
-    delegated: DELEGATED,
+    totalDeltas: TOTALDELTAS,
     unbonded: UNBONDED,
     bonded: BONDED,
+    slashes: SLASHES,
+    enqueuedSlashes: ENQUEUEDSLASHES,
     lastTx: TX,
     nextTxId: Int,
     failed: Bool
+  ];
+
+  @typeAlias: BOND = [
+    id: Int,
+    amount: Int,
+    epoch: Int
+  ];
+
+  @typeAlias: UNBOND = [
+    id: Int,
+    amount: Int,
+    start: Int,
+    end: Int
+  ];
+
+  @typeAlias: SLASH = [
+    id: Int,
+    epoch: Int,
+    stake: Int,
+    typeRate: Int,
+    finalRate: Int
   ];
 
   Below is a dummy definition to introduce the above type aliases.

--- a/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
+++ b/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
@@ -13,6 +13,8 @@
 
   @typeAlias: TOTALDELTAS = <<Int, ADDR>> -> Int;
 
+  @typeAlias: TOTALUNBONDED = <<Int, ADDR>> -> Int;
+
   @typeAlias: SLASHES = ADDR -> Set(SLASH);
 
   @typeAlias: ENQUEUEDSLASHES = <<Int, ADDR>> -> Set(SLASH);
@@ -33,6 +35,7 @@
   @typeAlias: STATE = [
     balanceOf: BALANCE,
     totalDeltas: TOTALDELTAS,
+    totalUnbonded: TOTALUNBONDED,
     unbonded: UNBONDED,
     bonded: BONDED,
     slashes: SLASHES,

--- a/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
+++ b/2022/Q3/artifacts/PoS-tla/Staking_typedefs.tla
@@ -17,6 +17,8 @@
 
   @typeAlias: ENQUEUEDSLASHES = <<Int, ADDR>> -> Set(SLASH);
 
+  @typeAlias: FROZEN = Int -> Set(ADDR);
+
   A transaction (a la discriminated union but all fields are packed together):
   @typeAlias: TX = [
     tag: Str,


### PR DESCRIPTION
This PR includes major changes to the TLA+ model:
- new data types for bonds and unbonds
- totalDeltas (old bonds) is twice the size (0..2*UnbondingLength). This is important to recover the stake of a validator when evidence for an epoch < cur_epoch is found.
- adds cubic slashing
- fix for https://github.com/informalsystems/partnership-heliax/issues/7
- fix for https://github.com/informalsystems/partnership-heliax/issues/21