### PR TITLE
Fix to issue #27

### DIFF
--- a/2022/Q3/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q3/artifacts/PoS-pseudocode/PoS-model.md
@@ -302,7 +302,7 @@ func withdraw(validator_address, delegator_address)
         updated_amount = amount - slashed_amount
       slashed_amount += updated_amount*slash.rate
       previous_slash_epoch = slash.epoch
-    amount_after_slashing = amount - slashed_amount
+    var amount_after_slashing = amount - slashed_amount
     balance[delegator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond

--- a/2022/Q3/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q3/artifacts/PoS-pseudocode/PoS-model.md
@@ -294,15 +294,17 @@ func withdraw(validator_address, delegator_address)
   var delunbonds = {<start,end,amount> | amount = unbonds[delegator_address][validator_address].deltas[(start, end)] > 0 && end <= cur_epoch }
   //substract any pending slash before withdrawing
   forall (<start,end,amount> in selfunbonds) do
+    
+    var computed_amounts = {}
     var updated_amount = amount
-    var slashed_amount = 0
-    var previous_slash_epoch = -1
-    forall (slash in slashes[validator_address] in slash.epoch order s.t. start <= slash.epoch && slash.epoch <= end)
-      if previous_slash_epoch == -1 || previous_slash_epoch + unbonding_length < slash.epoch do
-        updated_amount = amount - slashed_amount
-      slashed_amount += updated_amount*slash.rate
-      previous_slash_epoch = slash.epoch
-    var amount_after_slashing = amount - slashed_amount
+    forall (slash in slashes in slash.epoch order s.t. start <= slash.epoch && slash.epoch <= end) do
+      //Update amount with slashes that happened more than `unbonding_length` before this slash
+      forall (slashed_amount in computed_amounts s.t. slashed_amount.epoch + unbonding_length < slash.epoch) do
+        updated_amount -= slashed_amount.amount
+        computed_amounts = computed_amounts \ {slashed_amount}
+      computed_amounts = computed_amounts \union {SlashedAmount{epoch: slash.epoch, amount: updated_amount*slash.rate}}
+
+    var amount_after_slashing = updated_amount - sum({computed_amount.amount | computed_amount in computed_amounts})
     balance[delegator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond
@@ -404,7 +406,7 @@ func update_total_voting_power(offset)
   forall (epoch in epochs) do
     var total = 0
     var sets = read_epoched_field(validator_sets, epoch, ⊥)
-    forall (validator in sets.active U sets.inactive) do
+    forall (validator in sets.active \union sets.inactive) do
       total += validator.voting_power
     total_voting_power[epoch] = total
 }


### PR DESCRIPTION
This PR proposes a change in how slashable amounts are computed when a user withdraws. This fixes issue #27.

Note that for this to work, we need to iterate over the slashes in slash.epoch order. It would be great to get rid of this requirement (at least for the TLA+ model) but I could not figure out how. 