### PR TITLE
Fix issue 34 

### DIFF
--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -31,7 +31,7 @@ type Validator struct {
   consensus_key map<Epoch, Key>
   state map<Epoch, {inactive, candidate}>
   total_deltas map<Epoch, amount:int>
-  total_unbonds map<Epoch, amount:int>
+  total_unbonds map<Epoch, Set<UnbondRecord>>
   voting_power map<Epoch, VotingPower>
   reward_address Addr
   jail_record JailRecord
@@ -519,12 +519,12 @@ end_of_epoch()
       //find the total unbonded from the slash epoch up to the current epoch first
       //a..b notation determines an integer range: all integers between a and b inclusive
       forall (epoch in slash.epoch+1..cur_epoch) do
-        forall (unbond in validators[validator_address].total_unbonded[epoch] s.t. unbond.start <= slash.epoch)
+        forall (unbond in validators[validator_address].total_unbonds[epoch] s.t. unbond.start <= slash.epoch)
           total_unbonded += unbond.amount
 
       var last_slash = 0
       forall (offset in 1..unbonding_length) do
-        forall (unbond in validators[validator_address].total_unbonded[epoch] s.t. unbond.start <= slash.epoch)
+        forall (unbond in validators[validator_address].total_unbonds[epoch] s.t. unbond.start <= slash.epoch)
           total_unbonded += unbond.amount
         var this_slash = (total_staked - total_unbonded) * slash.rate
         var diff_slashed_amount = last_slash - this_slash

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -22,6 +22,11 @@ type UnbondRecord struct {
   start Epoch
 }
 
+type SlashedAmount struct {
+  epoch Epoch
+  amount uint
+}
+
 type Validator struct {
   consensus_key map<Epoch, Key>
   state map<Epoch, {inactive, candidate}>

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -513,7 +513,7 @@ end_of_epoch()
       forall (offset in 1..unbonding_length) do
         forall (unbond in validators[validator_address].total_unbonded[epoch] s.t. unbond.start <= slash.epoch)
           total_unbonded += unbond.amount
-        var this_slash = (total_staked + total_bonded - total_unbonded) * slash.rate
+        var this_slash = (total_staked - total_unbonded) * slash.rate
         var diff_slashed_amount = last_slash - this_slash
         last_slash = this_slash
         update_total_deltas(validator_address, offset, diff_slashed_amount)

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -503,7 +503,6 @@ end_of_epoch()
       var total_staked = read_epoched_field(validators[validator_address].total_deltas, slash.epoch, 0)
 
       var total_unbonded = 0
-      var total_bonded = 0
       //find the total unbonded from the slash epoch up to the current epoch first
       //a..b notation determines an integer range: all integers between a and b inclusive
       forall (epoch in slash.epoch+1..cur_epoch) do

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -280,8 +280,8 @@ func unbond(validator_address, delegator_address, unbond_amount)
           //The current model disregards a corner case that should be taken care of in the implementation:
           //- Assume a user delegates 10 tokens to a validator at epoch e1
           //- Assume the user unbonds twice 5 tokens from the same validator in the same epoch in two different transactions e2
-          //- When executing the first undelegate tx, the model creates the record UnbondRecord{amount: 5, start: e1 } and updates the bond to 5 tokens
-          //- When executing the second undelegate tx, the model creates the same record UnbondRecord{amount: 5, start: e1 } and removes the bond.
+          //- When executing the first undelegate tx, the model creates the record UnbondRecord{amount: 5, start: e1} and updates the bond to 5 tokens
+          //- When executing the second undelegate tx, the model creates the same record UnbondRecord{amount: 5, start: e1} and removes the bond.
           //- The problem is that we keep unbond records in a set and when we try to add the second record, since it is a duplicate, it will be discarded.
           //It is an easy fix I'd say: use a bag instead of a set to allow duplicates, or check if the set includes the record and act upon (remove it, create a new one with double the amount, and add it).
           //Same below


### PR DESCRIPTION
This PR fixes issue #34 in the pseudocode model.

The current model disregards a corner case that should be taken care of in the implementation:
- Assume a user delegates 10 tokens to a validator at epoch `e1`
- Assume the user unbonds twice 5 tokens from the same validator in the same epoch in two different transactions `e2`
- When executing the first undelegate tx, the model creates the record `UnbondRecord{amount: 5, start: e1 }` and updates the bond to 5 tokens
- When executing the second undelegate tx, the model creates the same record `UnbondRecord{amount: 5, start: e1 }` and removes the bond.
- The problem is that we keep unbond records in a set and when we try to add the second record, since it is a duplicate, it will be discarded.

It is an easy fix I'd say: use a bag instead of a set to allow duplicates, or check if the set includes the record and act upon (remove it, create a new one with double the amount, and add it). For now, I've left a comment on the model; I didn't want to "pollute" it. If we decide not to deal with it in the mode, I'll open an issue and refer to it in the model.
