### PR TITLE
More PoS pseudocode edits

### DIFF
--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -271,7 +271,8 @@ func unbond(validator_address, delegator_address, total_amount)
     var delbonds = {<start, amount> | amount = bonds[delegator_address][validator_address].deltas[start] > 0 && start <= cur_epoch + pipeline_len}
     if (sum{amount | <start, amount> in delbonds} >= total_amount) then
       var remain = total_amount
-      var amount_after_slashing = 0
+      var amount_after_slashing = 0 // Track the amount to change the deltas (may be less than `total_amount` due to previous slash processing)
+
       // Iterate over bonds and create unbond
       forall (<start, amount> in delbonds while remain > 0) do
         // Get the minimum of the remainder and the unbond, equal to amount if remain > amount and remain otherwise 

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -278,7 +278,7 @@ func unbond(validator_address, delegator_address, total_amount)
         // Get the minimum of the remainder and the unbond, equal to amount if remain > amount and remain otherwise 
         var amount_unbonded = min{amount, remain}
         bonds[delegator_address][validator_address].deltas[start] = amount - amount_unbonded
-        unbonds[delegator_address][validator_address].deltas[start, cur_epoch+pipeline_length+unbonding_length] = amount_unbonded
+        unbonds[delegator_address][validator_address].deltas[start, cur_epoch+pipeline_length+unbonding_length] += amount_unbonded
         // Set of slashes that happened while the bond was contributing to the validator's stake
         var set_slashes = {s | s in slashes[validator_address] && start <= slash.epoch }
         amount_after_slashing += compute_amount_after_slashing(set_slashes, amount_unbonded)

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -478,7 +478,6 @@ freeze_validator(validator_address)
   var epochs = {epoch | cur_epoch <= epoch <= cur_epoch+unbonding_length &&
                         (epoch > cur_epoch => validators[validator_address].frozen[epoch] != ⊥)}
   forall (epoch in epochs) do
-    var total = read_epoched_field(validators[validator_address].frozen, epoch, false)
     validators[validator_address].frozen[epoch] = true
   //schedule when to unfreeze the validator: after processing the enqueued slash
   validators[validator_address].frozen[cur_epoch+unbonding_length+1] = false

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -523,7 +523,7 @@ end_of_epoch()
       forall (epoch in slash.epoch+1..cur_epoch) do
         forall (unbond in validators[validator_address].set_unbonds[epoch] s.t. unbond.start <= slash.epoch)
           var set_prev_slashes = {s | s in slashes[validator_address] && unbond.start <= s.epoch && s.epoch + unbonding_length < slash.epoch}
-          total_unbonded = compute_amount_after_slashing(set_prev_slashes, unbond.amount)
+          total_unbonded += compute_amount_after_slashing(set_prev_slashes, unbond.amount)
 
       var last_slash = 0
       // up to pipeline_length because there cannot be any unbond in a greater ß (cur_epoch+pipeline_length is the upper bound)

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -98,12 +98,11 @@ total_voting_power[] in Epoch to VotingPower //map from epoch to voting_power
 ## Validator transactions
 
 ```go
-tx_become_validator(validator_address, consensus_key, staking_reward_address)
+tx_become_validator(validator_address, consensus_key)
 {
   // Check that become_validator has not been called before for validator_address
   var state = read_epoched_field(validators[validator_address].state, cur_epoch+pipeline_length, ⊥)
-  if (state == ⊥ && validator_address != staking_reward_address) then
-    validators[validator_address].reward_address = staking_reward_address
+  if (state == ⊥) then
     // Set status to candidate and consensus key at n + pipeline_length
     validators[validator_address].consensus_key[cur_epoch+pipeline_length] = consensus_key
     validators[validator_address].state[cur_epoch+pipeline_length] = candidate

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -541,7 +541,6 @@ end_of_epoch()
         last_slash = this_slash
         update_total_deltas(validator_address, offset, diff_slashed_amount)
         update_voting_power(validator_address, offset)
-        total_unbonded = 0
     //unfreeze the validator (Step 2.5 of cubic slashing)
     //this step is done in advance when the evidence is found
     //by setting validators[validator_address].frozen[cur_epoch+unbonding_length+1]=false

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -319,15 +319,15 @@ func withdraw(validator_address, delegator_address)
 ```go
 compute_amount_after_slashing(set_slashes, amount) {
   var computed_amounts = {}
-    var updated_amount = amount
-    forall (slash in set_slashes in slash.epoch order) do
-      //Update amount with slashes that happened more than `unbonding_length` before this slash
-      forall (slashed_amount in computed_amounts s.t. slashed_amount.epoch + unbonding_length < slash.epoch) do
-        updated_amount -= slashed_amount.amount
-        computed_amounts = computed_amounts \ {slashed_amount}
-      computed_amounts = computed_amounts \union {SlashedAmount{epoch: slash.epoch, amount: updated_amount*slash.rate}}
+  var updated_amount = amount
+  forall (slash in set_slashes in slash.epoch order) do
+    //Update amount with slashes that happened more than `unbonding_length` before this slash
+    forall (slashed_amount in computed_amounts s.t. slashed_amount.epoch + unbonding_length < slash.epoch) do
+      updated_amount -= slashed_amount.amount
+      computed_amounts = computed_amounts \ {slashed_amount}
+    computed_amounts = computed_amounts \union {SlashedAmount{epoch: slash.epoch, amount: updated_amount*slash.rate}}
 
-    return updated_amount - sum({computed_amount.amount | computed_amount in computed_amounts})
+  return updated_amount - sum({computed_amount.amount | computed_amount in computed_amounts})
 }
 ```
 

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -231,6 +231,7 @@ tx_withdraw_unbonds_delegator(delegator_address)
 //A priori, the only possible values for offset_length are pipeline_length and unbonding_length.
 //This would mean that epoched variables may be update at different offsets which would require special handling.
 */
+// Bond tokens to a validator address. This can be done even if a validator is frozen or jailed.
 func bond(validator_address, delegator_address, amount)
 {
   if is_validator(validator_address, cur_epoch+pipeline_length) then
@@ -261,6 +262,7 @@ func bond(validator_address, delegator_address, amount)
     conclusion: it is an actual issue, unresolved
 */
 // This function is called by transactions tx_unbond, tx_undelegate and tx_redelegate.
+// Unbonds tokens from one or more existing bonds. The validator deltas are updated and include the effects of slashing. The amount deducted from the stake may be less than the `total_amount` unbonded because an already-processed slash may have effectively slashed the validator's stake already due to the bond that is currently being unbonded. Unbonding is forbidden while the target validator is frozen, but is allowed while the validator is jailed and not frozen.
 func unbond(validator_address, delegator_address, total_amount)
 {
   // Disallow unbonding if validator is frozen, ensure that the address is a validator at pipeline epoch

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -501,6 +501,15 @@ func compute_stake_fraction(infraction, voting_power){
 ```
 
 ```go
+func get_min_slash_rate(infraction){
+  switch infraction
+    case duplicate_vote: return duplicate_vote_rate
+    case light_client_attack: return light_client_attack
+    default: panic()
+}
+```
+
+```go
 // Processes the enqueued slashes by calculating the cubic slashing rate and then slashing the validator's deltas (stake)
 end_of_epoch()
 {
@@ -512,8 +521,8 @@ end_of_epoch()
   var set_validators = {val | val = slash.validator && slash in enqueued_slashes[cur_epoch]}
   forall (validator_address in set_validators) do
     forall (slash in {s | s in enqueued_slashes[cur_epoch] && s.validator == validator_address}) do
-      slash.rate = rate
       // Set the slash on the now "finalized" slash amount in storage (Step 2.3 of cubic slashing)
+      slash.rate = max{get_min_slash_rate(slash), rate}
       append(slashes[validator_address], slash)
       var total_staked = read_epoched_field(validators[validator_address].total_deltas, slash.epoch, 0)
       

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -559,7 +559,7 @@ get_total_active_voting_power(epoch)
 {
   var voting_power = 0
   forall (validator in validator_sets[epoch].active)
-    voting_power += validator.voting_power
+    voting_power += read_epoched_field(validators[validator].voting_power, epoch, 0)
   return voting_power
 }
 ```

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -502,11 +502,11 @@ func compute_stake_fraction(infraction, voting_power){
 // Processes the enqueued slashes by calculating the cubic slashing rate and then slashing the validator's deltas (stake)
 end_of_epoch()
 {
-  //iterate over all slashes for infractions within (-1,+1) epochs range (Step 2.1 of cubic slashing)
+  // Iterate over all slashes for infractions within (-1,+1) epochs range (Step 2.1 of cubic slashing)
   var set_slashes = {s | s in enqueued_slashes[epoch] && cur_epoch-1 <= epoch <= cur_epoch+1}
-  //calculate the slash rate (Step 2.2 of cubic slashing)
+  // Calculate the cubic slash rate for all slashes processed this epoch (Step 2.2 of cubic slashing)
   var rate = compute_final_rate(set_slashes)
-
+  // Iterate over validators with enqueued slashes this epoch
   var set_validators = {val | val = slash.validator && slash in enqueued_slashes[cur_epoch]}
   forall (validator_address in set_validators) do
     forall (slash in {s | s in enqueued_slashes[cur_epoch] && s.validator == validator_address}) do

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -267,8 +267,8 @@ func unbond(validator_address, delegator_address, total_amount)
   // Disallow unbonding if validator is frozen, ensure that the address is a validator at pipeline epoch
   var frozen = read_epoched_field(validators[validator_address].frozen, cur_epoch, false)
   if (is_validator(validator_address, cur_epoch+pipeline_length) && frozen == false) then
-    var delbonds = {<start, amount> | amount = bonds[delegator_address][validator_address].deltas[start] > 0 && start <= cur_epoch + unbonding_length}
     // Compute sum of bonds from delegator to validator at the pipeline epoch (where an unbond will affect the deltas) and ensure that it is enough to accomodate the `total_amount` requested for unbonding
+    var delbonds = {<start, amount> | amount = bonds[delegator_address][validator_address].deltas[start] > 0 && start <= cur_epoch + pipeline_len}
     if (sum{amount | <start, amount> in delbonds} >= total_amount) then
       var remain = total_amount
       var amount_after_slashing = 0

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -54,8 +54,8 @@ type Slash struct {
   epoch Epoch
   validator Addr
   rate float
+  type string
   voting_power VotingPower // the voting power used to commit the infraction
-  slash_type string
 }
 
 type WeightedValidator struct {
@@ -343,19 +343,19 @@ compute_amount_after_slashing(set_slashes, amount) {
 /* COMMENT
   what about if the evidence is for the very last epoch? Problem with ranges: +1 may not exist.
 */
-func new_evidence(evidence)
+func new_evidence(validator, infraction_epoch, type)
 {
   //create slash
-  var total_staked = read_epoched_field(validators[evidence.validator].total_deltas, evidence.epoch, 0)
-  var slash = Slash{epoch: evidence.epoch, validator: evidence.validator, rate: 0, voting_power: total_staked}
+  var total_staked = read_epoched_field(validators[validator].total_deltas, infraction_epoch, 0)
+  var slash = Slash{epoch: infraction_epoch, validator: validator, rate: 0, type: type, voting_power: total_staked}
   //enqueue slash (Step 1.1 of cubic slashing)
-  append(enqueued_slashes[evidence.epoch + unbonding_length], slash)
+  append(enqueued_slashes[infraction_epoch + unbonding_length], slash)
   //jail validator (Step 1.2 of cubic slashing)
-  validators[validator_address].jail_record = JailRecord{is_jailed: true, epoch: cur_epoch+1}
-  remove_validator_from_sets(validator_address, 1)
+  validators[validator].jail_record = JailRecord{is_jailed: true, epoch: cur_epoch+1}
+  remove_validator_from_sets(validator, 1)
   update_total_voting_power(1)
   //freeze validator to prevent delegators from altering their delegations (Step 1.3 of cubic slashing)
-  freeze_validator(validator_address)
+  freeze_validator(validator)
 }
 ```
 

--- a/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
+++ b/2022/Q4/artifacts/PoS-pseudocode/PoS-model.md
@@ -240,11 +240,11 @@ func bond(validator_address, delegator_address, amount)
     // Debit amount from delegator account and credit it to the PoS account
     balances[delegator_address] -= amount
     balances[pos] += amount
-    update_total_deltas(validator_address, pipeline_lenght, amount)
-    update_voting_power(validator_address, pipeline_lenght)
-    update_total_voting_power(pipeline_lenght)
-    update_validator_sets(validator_address, pipeline_lenght)
     // Update voting powers and validator set
+    update_total_deltas(validator_address, pipeline_length, amount)
+    update_voting_power(validator_address, pipeline_length)
+    update_total_voting_power(pipeline_length)
+    update_validator_sets(validator_address, pipeline_length)
 }
 ```
 


### PR DESCRIPTION
Miscellaneous edits and updates to the PoS pseudocode. Also includes updates that align the pseudocode more closely with the Namada implementation. The changes here reflect those that were addressed before discovering the need to adjust procedures in order to prevent validator deltas from going negative. This is in light of the Namada slashing conditions being broader than those allowed for in the TLA+ model. In particular, in the TLA+, a validator can only misbehave once within a single window of `unbonding_len` epochs.