### PR TITLE
Add redelegation to the pseudocode model

### DIFF
--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -280,8 +280,7 @@ The transaction `tx_redelegate` creates a redelegation from source validator `sr
 1. The function first checks that the source validator is not frozen. This is to prevent unbonding at an epoch `e` from a validator that it is known to have behaved, but the slash has not been processed yet.
 2. Then it checks that the redelegation is not a chain redelegation, in which case it prevents it by returning.
    - The design does not track chain redelegation precisely.
-   - Instead approximates it by preventing a validator to redelegate tokens belonging to a delegator if it has recently received a redelegation of tokens belonging to the same delegator.
-   - The `incoming_redelegations` variable is used to implement this mechanism.
+   - Instead approximates it by preventing a validator to redelegate tokens belonging to a delegator if it has received a redelegation of tokens belonging to the same delegator that ended `unbonding_length` epochs ago. Please read the definition of chain redelegation in [Definitions](#definitions) for more details.
 3. The function computes the total amount of tokens that the delegator has bonded at the source validator (`bonded_tokens`).
 4. It unbonds `bonded_tokens` from the source validator indicating that it is a redelegation by calling `unbond` with the delegator's address.
 5. It creates the bond at the destination validator.

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -634,7 +634,7 @@ end_of_epoch()
       slash.rate = rate
       append(slashes[validator_address], slash)
       var total_staked = read_epoched_field(validators[validator_address].total_deltas, slash.epoch, 0)
-      slash_misbehaving_validator(validator_address, slash, staked_amount)
+      slash_misbehaving_validator(validator_address, slash, total_staked)
 
       forall (val in validators) do
         var pairs = { pair = <delegator, <epoch, redelegation> | pair in validators[val].redelegations[validator_address] &&

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -219,10 +219,10 @@ tx_undelegate(validator_address, delegator_address, amount)
 ```
 
 ```go
-func is_chained_redelegation(dest_validator_address, delegator_address)
+func is_chained_redelegation(validator_address, delegator_address)
   // avoid iteration over validators and do it over incoming_redelegations
   forall (val in validators) do
-    var redelegation = validators[dest_validator_address].redelegations[val][delegator_address]
+    var redelegation = validators[validator_address].redelegations[val][delegator_address]
     if (redelegation.epoch >= 0 && redelegation.epoch + unbonding_length > cur_epoch) then
       return true
   return false
@@ -234,7 +234,7 @@ tx_redelegate(src_validator_address, dest_validator_address, delegator_address)
   // Disallow re-delegation if the source validator is frozen (similar to unbonding)
   var src_frozen = read_epoched_field(validators[src_validator_address].frozen, cur_epoch, false)
   if (is_validator(src_validator_address, cur_epoch+pipeline_length) && src_frozen == false) then
-    // Check that `incoming_redelegations[delegator_address]` for `dest_validator_address` either don't exist
+    // Check that `incoming_redelegations[delegator_address]` for `src_validator_address` either don't exist
     // or if they do, they cannot be slashed anymore (`end + unbonding_length <= cur_epoch`)
     if is_chained_redelegation(src_validator_address, delegator_address) then
       return

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -374,7 +374,7 @@ func unbond(validator_address, delegator_address, total_amount, dest_validator_a
       var amount_after_slashing = 0
       //iterate over bonds and create unbonds
       forall (<start, amount> in delbonds while remain > 0) do
-        //Retrieve the bond's associated redelegation record (if any)
+        //Retrieve the bond's associated redelegation records (if any)
         var number_redelegations = redelegated_bonds[delegator_address][validator_address][start].size()
         //Take the minimum between the remainder and the unbond. This is equal to amount if remain > amount and remain otherwise 
         var amount_unbonded = min{amount, remain}

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -540,7 +540,7 @@ func new_evidence(evidence)
 func compute_stake_fraction(infraction, voting_power){
   switch infraction
     case duplicate_vote: return duplicate_vote_rate * voting_power
-    case ligth_client_attack: return ligth_client_attack_rate * voting_power
+    case light_client_attack: return light_client_attack_rate * voting_power
     default: panic()
 }
 ```

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -737,7 +737,7 @@ func slash_redelegated_validator(validator_address, src_validator, slash, staked
                              unbond.start - unbonding_length - pipeline_length <= s.epoch &&
                              s.epoch + unbonding_length < slash.epoch }
 
-      total_unbonded = compute_amount_after_slashing(set_slashes, unbond.amount)
+      total_unbonded += compute_amount_after_slashing(set_slashes, unbond.amount)
 
   var last_slash = 0
   // up to pipeline_length because there cannot be any unbond in a greater ß (cur_epoch+pipeline_length is the upper bound)

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -236,7 +236,7 @@ tx_redelegate(src_validator_address, dest_validator_address, delegator_address)
   if (is_validator(src_validator_address, cur_epoch+pipeline_length) && src_frozen == false) then
     // Check that `incoming_redelegations[delegator_address]` for `dest_validator_address` either don't exist
     // or if they do, they cannot be slashed anymore (`end + unbonding_length <= cur_epoch`)
-    if is_chained_redelegation(dest_validator_address, delegator_address) then
+    if is_chained_redelegation(src_validator_address, delegator_address) then
       return
     // Find the sum of bonded tokens to `src_validator_address`
     var delbonds = {<start, amount> | amount = bonds[delegator_address][src_validator_address].deltas[start] > 0 && start <= cur_epoch + unbonding_length}

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -30,7 +30,7 @@
 
 - Given a `redelegation`, the `redelegation's starting epoch` is the epoch at which the redelegation transaction is processed. The `redelegation's ending epoch` is the epoch at which the redelegated tokens start contributing to the destination delegator. In the current design, if a redelegation's starting epoch is `e`, then its ending epoch would be `e + pipeline_length`. In the text throughout the specification, for a given `redelegation`, we use `redelegation.start` and `redelegation.end` to refer to the starting and ending epoch of the redelegation.
 
-- A redelegation is composed by one or more bonds (aka `redelegation bonds`). Each redelegation bond is a pair the epoch at which the redelegated tokens started contributing to the stake of the source validator and the amount of tokens. It is important to keep track of the starting epochs in order to apply slashes precisely.
+- A redelegation is composed of one or more bonds (aka `redelegation bonds`). Each redelegation bond is a pair of the epoch at which the redelegated tokens started contributing to the stake of the source validator and the amount of tokens. It is important to keep track of the starting epochs in order to apply slashes precisely.
 
 - Given a redelegation, we call `redelegation slashing window` the set of consecutive epoch in which the destination validator may be slashed due to the misbehave of the source validator.
   - In the current design, the redelegation slashing window of a redelegation spans from `redelegation.start - unbonding_length` up to `redelegation.end - 1`.

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -281,7 +281,7 @@ The transaction `tx_redelegate` creates a redelegation from source validator `sr
 2. Then it checks that the redelegation is not a chain redelegation, in which case it prevents it by returning.
    - The design does not track chain redelegation precisely.
    - Instead approximates it by preventing a validator to redelegate tokens belonging to a delegator if it has recently received a redelegation of tokens belonging to the same delegator.
-   - The `inconming_redelegations` variable is used to implement this mechanism.
+   - The `incoming_redelegations` variable is used to implement this mechanism.
 3. The function computes the total amount of tokens that the delegator has bonded at the source validator (`bonded_tokens`).
 4. It unbonds `bonded_tokens` from the source validator indicating that it is a redelegation by calling `unbond` with the delegator's address.
 5. It creates the bond at the destination validator.

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -252,7 +252,7 @@ tx_redelegate(src_validator_address, dest_validator_address, delegator_address)
                                                                                                            amount: amount_after_slashing}
     //save the epoch at which the redelegation occurs to track chained redelegations
     validators[dest_validator_address].redelegations[src_validator_address][delegator_address] = IncomingRedelegation{epoch: cur_epoch,
-                                                                                                                      amoun: amount_after_slashing}
+                                                                                                                      amount: amount_after_slashing}
     update_total_deltas(dest_validator_address, pipeline_length, amount_after_slashing)
     update_voting_power(dest_validator_address, pipeline_length)
     update_total_voting_power(pipeline_length)
@@ -408,7 +408,7 @@ func withdraw(validator_address, delegator_address)
 {
   var delunbonds = {<start,end,amount> | amount = unbonds[delegator_address][validator_address].deltas[(start, end)] > 0 && end <= cur_epoch }
   //substract any pending slash before withdrawing
-  forall (<start,end,amount,redelegation_record> in selfunbonds) do
+  forall (<start,end,amount,redelegation_record> in delunbonds) do
     //retrieve redelegation record
     var redelegation_record = redelegated_unbonds[delegator_address][validator_address][start, end]
     var redelegated_amount = 0
@@ -637,7 +637,7 @@ end_of_epoch()
       slash_misbehaving_validator(validator_address, slash, staked_amount)
 
       forall (val in validators) do
-        var pairs = { pair = <delegator, <epoch, redelegation> | pair in validators[var].redelegations[validator_address] &&
+        var pairs = { pair = <delegator, <epoch, redelegation> | pair in validators[val].redelegations[validator_address] &&
                                                                  pair !=⊥ && 
                                                                  redelegation.epoch - unbonding_length <= slash.epoch < redelegation.epoch + pipeline_length}
         forall (<delegator, redelegation> in pairs) do

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -696,22 +696,22 @@ func slash_misbehaving_validator(src_validator_address, dest_validator_address, 
   forall (offset in 1..pipeline_length) do
     forall (unbond in validators[validator_address].set_unbonds[cur_epoch + offset] s.t. unbond.start <= slash.epoch) do
 
-    //retrieve redelegation record
-    var redelegation_record = unbond.redelegation
-    var redelegated_amount = 0
-    if redelegation_record != ⊥ then
-      redelegated_amount = redelegation_record.amount
-    // set of slashes that happened while the bond was contributing to the validator's stake
-    var set_slashes = {s | s in slashes[validator_address] &&
-                            unbond.start <= s.epoch &&
-                            s.epoch + unbonding_length < slash.epoch }
-    var total_unbonded = compute_amount_after_slashing(set_slashes, unbond.amount - redelegated_amount)
-    if redelegation_record != ⊥ then
-      // add slashes if the tokens were redelegated
-      set_slashes = set_slashes \union {s | s in slashes[redelegation_record.validator] &&
-                                            unbond.start - pipeline_length - unbonding_length <= s.epoch < unbond.start &&
-                                            s.epoch + unbonding_length < slash.epoch}
-      total_unbonded += compute_amount_after_slashing(set_slashes, redelegated_amount)
+      //retrieve redelegation record
+      var redelegation_record = unbond.redelegation
+      var redelegated_amount = 0
+      if redelegation_record != ⊥ then
+        redelegated_amount = redelegation_record.amount
+      // set of slashes that happened while the bond was contributing to the validator's stake
+      var set_slashes = {s | s in slashes[validator_address] &&
+                              unbond.start <= s.epoch &&
+                              s.epoch + unbonding_length < slash.epoch }
+      var total_unbonded = compute_amount_after_slashing(set_slashes, unbond.amount - redelegated_amount)
+      if redelegation_record != ⊥ then
+        // add slashes if the tokens were redelegated
+        set_slashes = set_slashes \union {s | s in slashes[redelegation_record.validator] &&
+                                              unbond.start - pipeline_length - unbonding_length <= s.epoch < unbond.start &&
+                                              s.epoch + unbonding_length < slash.epoch}
+        total_unbonded += compute_amount_after_slashing(set_slashes, redelegated_amount)
 
     var this_slash = (total_staked - total_unbonded) * slash.rate
     var diff_slashed_amount = last_slash - this_slash

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -35,7 +35,7 @@
 - Given a redelegation, we call `redelegation slashing window` the set of consecutive epochs in which the destination validator may be slashed due to the misbehaviour of the source validator.
   - In the current design, the redelegation slashing window of a redelegation spans from `redelegation.start - unbonding_length` up to `redelegation.end - 1`.
   - The window's lower bound if determined by the fact that when a redelegation is issued, we apply all slashes of the source validator already processed. This means any slash for an infraction committed at en epoch `< redelegation.start - unbonding_length`.
-  - The window's upper bound is determined by the epoch at which the redelegated tokens stop contributing to the stake to the source validator.
+  - The window's upper bound is determined by the epoch at which the redelegated tokens stop contributing to the stake of the source validator.
 
 - We say a redelegation is a `chain redelegation` when the source validator redelegates some tokens that were redelegated by a second validator while infractions of the latter validator can still be processed. In the current design, a redelegation is considered a chain redelegation if already redelegated tokens are redelegated before the end of the initial redelegation `+ unbonding_length`. This is simple to compute:
   - Let `redelegation` be the initial redelegation and assume that `redelegation.start = e`.

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -654,7 +654,7 @@ end_of_epoch()
 ```
 
 ```go
-func slash_misbehaving_validator(src_validator_address, dest_validator_address, slash, amount)
+func slash_misbehaving_validator(src_validator_address, dest_validator_address, slash, total_staked)
 {
   var total_unbonded = 0
   //find the total unbonded from the slash epoch up to the current epoch first
@@ -677,7 +677,7 @@ func slash_misbehaving_validator(src_validator_address, dest_validator_address, 
       var set_slashes = {s | s in slashes[validator_address] &&
                              unbond.start <= s.epoch &&
                              s.epoch + unbonding_length < slash.epoch }
-      var total_unbonded = compute_amount_after_slashing(set_slashes, unbond.amount - redelegated_amount)
+     total_unbonded += compute_amount_after_slashing(set_slashes, unbond.amount - redelegated_amount)
       if redelegation_record != ⊥ then
         // add slashes if the tokens were redelegated
         set_slashes = set_slashes \union {s | s in slashes[redelegation_record.validator] &&

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -37,7 +37,7 @@ type Validator struct {
   reward_address Addr
   jail_record JailRecord
   frozen map<Epoch, bool>
-  redelegations map<Addr, map<Addr, Epoch>>
+  redelegations map<Addr, map<Addr, IncomingRedelegation>>
 }
 
 type Bond struct {

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -548,7 +548,7 @@ func compute_stake_fraction(infraction, voting_power){
 The function `end_of_epoch` is called at the end of every epoch. It takes the following steps:
 
 1. It first computes the slash rate for any slash that has to be processed at the end of the current epoch.
-2. The iterates over the enqueued slashes. For each slash:
+2. It then iterates over the enqueued slashes. For each slash:
    - It appends the slash to the misbehaving validator's set of slashes.
    - It uses the `slash_validator` function to slash the misbehaving validator.
    - It iterates over all validators to which there is an ongoing redelegation from the misbehaving validator. For each destination validator, the function computes the total amount of tokens that are slashable: those belonging to a redelegation for which (i) the redelegation's slashing window includes the misbehaving epoch, and (ii) that were bonded to the the source validator before the misbehaving epoch. If there are tokens to be slashed (`total_amount > 0`), then the function uses `slash_validator` to slash the destination validator.

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -32,7 +32,7 @@
 
 - A redelegation is composed of one or more bonds (aka `redelegation bonds`). Each redelegation bond is a pair of the epoch at which the redelegated tokens started contributing to the stake of the source validator and the amount of tokens. It is important to keep track of the starting epochs in order to apply slashes precisely.
 
-- Given a redelegation, we call `redelegation slashing window` the set of consecutive epoch in which the destination validator may be slashed due to the misbehave of the source validator.
+- Given a redelegation, we call `redelegation slashing window` the set of consecutive epochs in which the destination validator may be slashed due to the misbehaviour of the source validator.
   - In the current design, the redelegation slashing window of a redelegation spans from `redelegation.start - unbonding_length` up to `redelegation.end - 1`.
   - The window's lower bound if determined by the fact that when a redelegation is issued, we apply all slashes of the source validator already processed. This means any slash for an infraction committed at en epoch `< redelegation.start - unbonding_length`.
   - The window's upper bound is determined by the epoch at which the redelegated tokens stop contributing to the stake to the source validator.

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -22,7 +22,7 @@
 
 ## Definitions
 
-- `pipeline_length` and `unbonding_length` define two epoch offsets. Note that `pipeline_length` must be greater or equal to `unbonding_length`.
+- `pipeline_length` and `unbonding_length` define two epoch offsets. Note that `pipeline_length` must be equal to or greater than `unbonding_length`.
 
 ### Redelegations' Specific Terminology
 

--- a/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
+++ b/2023/Q1/artifacts/PoS-pseudocode/PoS-model-redelegation.md
@@ -1,10 +1,51 @@
+# Namada's Cubic Proof-of-Stake
+
+- [Namada's Cubic Proof-of-Stake](#namadas-cubic-proof-of-stake)
+  - [Assumptions/simplifications](#assumptionssimplifications)
+  - [Definitions](#definitions)
+    - [Redelegations' Specific Terminology](#redelegations-specific-terminology)
+  - [Technical Specification](#technical-specification)
+    - [Data types](#data-types)
+    - [Constants](#constants)
+    - [Variables](#variables)
+    - [Validator transactions](#validator-transactions)
+    - [Bonding Mechanism Transactions](#bonding-mechanism-transactions)
+    - [Main PoS functions](#main-pos-functions)
+    - [Validator's functions](#validators-functions)
+    - [Auxiliary functions](#auxiliary-functions)
+
 ## Assumptions/simplifications
 
 - There is a single token type
 - There is an initial set of active and inactive validators
 - There are always enough non-jalied, candidate validators to fulfill the active set of validators at any given epoch
 
-## Data types
+## Definitions
+
+- `pipeline_length` and `unbonding_length` define two epoch offsets. Note that `pipeline_length` must be greater or equal to `unbonding_length`.
+
+### Redelegations' Specific Terminology
+
+- A redelegation involves two validators. We use `source validator` to refer the validator from which the tokens are taken and `destination validator` to to refer to the validator to which the tokens are delegated.
+
+- Given a `redelegation`, the `redelegation's starting epoch` is the epoch at which the redelegation transaction is processed. The `redelegation's ending epoch` is the epoch at which the redelegated tokens start contributing to the destination delegator. In the current design, if a redelegation's starting epoch is `e`, then its ending epoch would be `e + pipeline_length`. In the text throughout the specification, for a given `redelegation`, we use `redelegation.start` and `redelegation.end` to refer to the starting and ending epoch of the redelegation.
+
+- A redelegation is composed by one or more bonds (aka `redelegation bonds`). Each redelegation bond is a pair the epoch at which the redelegated tokens started contributing to the stake of the source validator and the amount of tokens. It is important to keep track of the starting epochs in order to apply slashes precisely.
+
+- Given a redelegation, we call `redelegation slashing window` the set of consecutive epoch in which the destination validator may be slashed due to the misbehave of the source validator.
+  - In the current design, the redelegation slashing window of a redelegation spans from `redelegation.start - unbonding_length` up to `redelegation.end - 1`.
+  - The window's lower bound if determined by the fact that when a redelegation is issued, we apply all slashes of the source validator already processed. This means any slash for an infraction committed at en epoch `< redelegation.start - unbonding_length`.
+  - The window's upper bound is determined by the epoch at which the redelegated tokens stop contributing to the stake to the source validator.
+
+- We say a redelegation is a `chain redelegation` when the source validator redelegates some tokens that were redelegated by a second validator while infractions of the latter validator can still be processed. In the current design, a redelegation is considered a chain redelegation if already redelegated tokens are redelegated before the end of the initial redelegation `+ unbonding_length`. This is simple to compute:
+  - Let `redelegation` be the initial redelegation and assume that `redelegation.start = e`.
+  - The redelegation slashing window then spans from `redelegation.start - unbonding_length` up to `redelegation.end - 1`. Thus, the last epoch at which the source validator may misbehave and we need to account for it is `redelegation.end - 1 = redelegation.start + pipeline_length - 1 = e + pipeline_length - 1`.
+  - An infraction is processed after `unbonding_length` epoch from the misbehaving epoch. Thus, if the source validator misbehaves at `redelegation.end - 1`, the infraction will be processed at the end of epoch `redelegation.end - 1 + unbonding_length`.
+  - Therefore, a redelegation of the redelegated tokens of `redelegation` is only considered a chain redelegation if it occurs before `redelegation.end + unbonding_length` as required.
+
+## Technical Specification
+
+### Data types
 
 ```go
 type Addr
@@ -18,9 +59,8 @@ type JailRecord struct {
 }
 
 type UnbondRecord struct {
-  amount uint
   start Epoch
-  redelegation Redelegation
+  amount uint
 }
 
 type SlashedAmount struct {
@@ -32,13 +72,14 @@ type Validator struct {
   consensus_key map<Epoch, Key>
   state map<Epoch, {inactive, candidate}>
   total_deltas map<Epoch, amount:int>
-  set_unbonds map<Epoch, Set<UnbondRecord>>
+  total_unbonded map<(Epoch, Epoch), int>
+  total_redelegated_unbonded map<(Epoch, Epoch), map<Addr, int>>
   voting_power map<Epoch, VotingPower>
   reward_address Addr
   jail_record JailRecord
   frozen map<Epoch, bool>
   incoming_redelegations map<Addr, map<Addr, int>>
-  outgoing_redelegations map<Addr, map<Addr, map<Epoch, int>>>
+  outgoing_redelegations map<Addr, map<Addr, map<(Epoch, Epoch), int>>>
 }
 
 type Bond struct {
@@ -62,7 +103,7 @@ type Slash struct {
 
 type Redelegation struct {
   validator Addr
-  amount uint
+  bonds map<Epoch, int> // map from bond start epoch to bond amount
 }
 
 type WeightedValidator struct {
@@ -76,7 +117,7 @@ type ValidatorSet struct {
 }
 ```
 
-## Constants
+### Constants
 
 ```go
 pipeline_length uint
@@ -87,7 +128,7 @@ duplicate_vote_rate float
 ligth_client_attack_rate float
 ```
 
-## Variables
+### Variables
 
 ```go
 cur_epoch ← 0 in Epoch //current epoch
@@ -105,7 +146,7 @@ validator_sets[] in Epoch → ValidatorSet //map from epoch to validator_set
 total_voting_power[] in Epoch to VotingPower //map from epoch to voting_power
 ```
 
-## Validator transactions
+### Validator transactions
 
 ```go
 tx_become_validator(validator_address, consensus_key, staking_reward_address)
@@ -171,34 +212,24 @@ tx_unjail(validator_address)
 ```
 
 ```go
-tx_self_bond(validator_address, amount)
-{
-  bond(validator_address, validator_address, amount, pipeline_length)
-}
-```
-
-```go
-tx_unbond(validator_address, amount)
-{
-  unbond(validator_address, validator_address, amount)
-}
-```
-
-```go
-tx_withdraw_unbonds_validator(validator_address)
-{
-  withdraw(validator_address, validator_address)
-}
-```
-
-```go
 tx_change_consensus_key(validator_address, consensus_key)
 {
   //set consensus key at n + pipeline_length
   validators[validator_address].consensus_key[cur_epoch+pipeline_length] = consensus_key
 }
 ```
-## Delegator transactions
+### Bonding Mechanism Transactions
+
+The transaction `tx_self_bond` calls the `bond` function to self-bond `amount` tokens to a validator `validator_address`.
+
+```go
+tx_self_bond(validator_address, amount)
+{
+  bond(validator_address, validator_address, amount, pipeline_length)
+}
+```
+
+The transaction `tx_delegate` calls the `bond` function to delegate `amount` tokens belonging to a delegator `delegator_address` to a validator `validator_address`.
 
 ```go
 tx_delegate(validator_address, delegator_address, amount)
@@ -207,46 +238,34 @@ tx_delegate(validator_address, delegator_address, amount)
 }
 ```
 
+The transaction `tx_unbond` calls the `unbond` function to unbond `amount` self-bond tokens from a validator `validator_address`.
+
 ```go
-tx_undelegate(validator_address, delegator_address, amount)
+tx_unbond(validator_address, amount)
 {
-  unbond(validator_address, delegator_address, amount)
+  unbond(validator_address, validator_address, amount)
 }
 ```
 
+The transaction `tx_undelegate` calls the `unbond` function to unbond `amount` tokens from a validator `validator_address` previously delegated by a delegator `delegator_address`.
+
 ```go
-tx_redelegate(src_validator_address, dest_validator_address, delegator_address)
+tx_undelegate(validator_address, delegator_address, amount)
 {
-  // Disallow re-delegation if the source validator is frozen (similar to unbonding)
-  var src_frozen = read_epoched_field(validators[src_validator_address].frozen, cur_epoch, false)
-  if (is_validator(src_validator_address, cur_epoch+pipeline_length) && src_frozen == false) then
-    // Check that `incoming_redelegations[delegator_address]` for `src_validator_address` either don't exist
-    // or if they do, they cannot be slashed anymore (`end + unbonding_length <= cur_epoch`)
-    var last_epoch_redelegation = validators[validator_address].incoming_redelegations[delegator_address]
-    if (last_epoch_redelegation >= 0 && last_epoch_redelegation + unbonding_length > cur_epoch) then
-      return
-    // Find the sum of bonded tokens to `src_validator_address`
-    var delbonds = {<start, amount> | amount = bonds[delegator_address][src_validator_address].deltas[start] > 0 && start <= cur_epoch + unbonding_length}
-    var bonded_tokens = sum{amount | <start, amount> in delbonds}
-    // Unbond the tokens from `src_validator_address` at pipeline offset, but 
-    // without recording it in the `unbonds[delegator_address][src_validator_address]`
-    var record_unbonds = false
-    var amount_after_slashing = unbond(src_validator_address, delegator_address, bonded_tokens, record_unbonds)
-    // add a bond in the `dest_validator_address` for the amount after slashing
-    // done manually to avoid account transfer
-    bonds[delegator_address][dest_validator_address].deltas[cur_epoch+pipeline_length] += amount_after_slashing
-    redelegated_bonds[delegator_address][dest_validator_address][cur_epoch+pipeline_length] = Redelegation{validator: src_validator_address,
-                                                                                                           amount: amount_after_slashing}
-    // update total redelegated between the pair of validators
-    validators[src_validator_address].outgoing_redelegations[dest_validator_address][cur_epoch] += amount_after_slashing
-    // save the epoch at which the redelegation occurs to track chained redelegations
-    validators[dest_validator_address].incoming_redelegations[delegator_address] = cur_epoch
-    update_total_deltas(dest_validator_address, pipeline_length, amount_after_slashing)
-    update_voting_power(dest_validator_address, pipeline_length)
-    update_total_voting_power(pipeline_length)
-    update_validator_sets(dest_validator_address, pipeline_length)
+  unbond(validator_address, delegator_address, amount, "")
 }
 ```
+
+The transaction `tx_withdraw_unbonds_validator` calls the `withdraw` function to withdraw all tokens that `validator_address` has unbonded from itself.
+
+```go
+tx_withdraw_unbonds_validator(validator_address)
+{
+  withdraw(validator_address, validator_address)
+}
+```
+
+The transaction `tx_withdraw_unbonds_delegator` calls the `withdraw` function to withdraw all tokens that a delegator `delegator_address` has unbonded from a validator `validator_address`.
 
 ```go
 tx_withdraw_unbonds_delegator(delegator_address)
@@ -256,18 +275,63 @@ tx_withdraw_unbonds_delegator(delegator_address)
 }
 ```
 
-## PoS functions
+The transaction `tx_redelegate` creates a redelegation from source validator `src_validator_address` to `dest_validator_address` for any tokens that a delegator `delegator_address` has currently delegated to the source validator. The transactions takes the following steps:
+
+1. The function first checks that the source validator is not frozen. This is to prevent unbonding at an epoch `e` from a validator that it is known to have behaved, but the slash has not been processed yet.
+2. Then it checks that the redelegation is not a chain redelegation, in which case it prevents it by returning.
+   - The design does not track chain redelegation precisely.
+   - Instead approximates it by preventing a validator to redelegate tokens belonging to a delegator if it has recently received a redelegation of tokens belonging to the same delegator.
+   - The `inconming_redelegations` variable is used to implement this mechanism.
+3. The function computes the total amount of tokens that the delegator has bonded at the source validator (`bonded_tokens`).
+4. It unbonds `bonded_tokens` from the source validator indicating that it is a redelegation by calling `unbond` with the delegator's address.
+5. It creates the bond at the destination validator.
+6. It stores the redelegation's end epoch in the destination validator `incoming_redelegations` variable.
+7. It finally updates the destination validator `total_deltas`, voting power, total voting power and validator sets.
 
 ```go
-//This function is called by transactions tx_self_bond, tx_delegate and tx_redelegate
-/* COMMENT
-//When adding redelegate, the bond function may be parametrized with offset_length.
-//A priori, the only possible values for offset_length are pipeline_length and unbonding_length.
-//This would mean that epoched variables may be update at different offsets which would require special handling.
-*/
+tx_redelegate(src_validator_address, dest_validator_address, delegator_address)
+{
+  // Disallow re-delegation if the source validator is frozen (similar to unbonding)
+  var src_frozen = read_epoched_field(validators[src_validator_address].frozen, cur_epoch, false)
+  if (is_validator(src_validator_address, cur_epoch+pipeline_length) && src_frozen == false) then
+    // Check that `incoming_redelegations[delegator_address]` for `src_validator_address` either don't exist
+    // or if they do, they cannot be slashed anymore (`end + unbonding_length <= cur_epoch`)
+    var end_epoch_redelegation = validators[src_validator_address].incoming_redelegations[delegator_address]
+    if (end_epoch_redelegation >= 0 && end_epoch_redelegation + unbonding_length > cur_epoch) then
+      return
+    // Find the sum of bonded tokens to `src_validator_address`
+    var delbonds = {<start, amount> | amount = bonds[delegator_address][src_validator_address].deltas[start] > 0 && start <= cur_epoch + unbonding_length}
+    var bonded_tokens = sum{amount | <start, amount> in delbonds}
+    // Unbond the tokens from `src_validator_address` at pipeline offset, but 
+    // without recording it in the `unbonds[delegator_address][src_validator_address]`
+    var record_unbonds = false
+    var amount_after_slashing = unbond(src_validator_address, delegator_address, bonded_tokens, dest_validator_address)
+    // add a bond in the `dest_validator_address` for the amount after slashing
+    // done manually to avoid account transfer
+    bonds[delegator_address][dest_validator_address].deltas[cur_epoch+pipeline_length] += amount_after_slashing
+    // save the epoch at which the redelegation occurs to track chained redelegations
+    validators[dest_validator_address].incoming_redelegations[delegator_address] = cur_epoch + pipeline_length
+    update_total_deltas(dest_validator_address, pipeline_length, amount_after_slashing)
+    update_voting_power(dest_validator_address, pipeline_length)
+    update_total_voting_power(pipeline_length)
+    update_validator_sets(dest_validator_address, pipeline_length)
+}
+```
+
+### Main PoS functions
+
+The `bond` function delegates `amount` tokens belonging to a delegator `delegator_address` to a validator `validator_address`. It takes the following steps:
+
+1. It checks that `validator_address` is a validator and that the delegator has enough balance.
+2. Then it registers a bond with start epoch `cur_epoch+pipeline_length` of `amount` tokens.
+3. It transfers `amount` from the delegator's account to the PoS account.
+4. It finally updates the destination validator `total_deltas`, voting power, total voting power and validator sets.
+
+```go
 func bond(validator_address, delegator_address, amount)
 {
-  if is_validator(validator_address, cur_epoch+pipeline_length) then
+  if (is_validator(validator_address, cur_epoch+pipeline_length) && 
+     balances[delegator_address] >= amount) then
     //add amount bond to delta at n+pipeline_length
     bonds[delegator_address][validator_address].deltas[cur_epoch+pipeline_length] += amount
     //debit amount from delegator account and credit it to the PoS account
@@ -280,21 +344,23 @@ func bond(validator_address, delegator_address, amount)
 }
 ```
 
+The `unbond` function unbonds `total_amount` tokens to belonging to a delegator `delegator_address` from a validator `validator_address`. The function takes a fourth argument `dest_validator_address`. If the function is called by the redelegation transaction, then the unbonding is triggered due to a redelegation and `dest_validator_address` determines the address of the destination validator. It is set to `""` otherwise. The function takes the following steps:
+
+1. It first checks that `validator_address` is a validator and it is not frozen.
+2. Then it computes the total amount of tokens that the delegator has currently bonded to the validator.
+3. If the total amount is less than `total_amount`, the function returns.
+4. If the total amount is at least `total_amount`, it computes how much of `total_amount` is effectively unbonded after slashing and stores it in `amount_after_slashing`. This computation is done by iterating over the bonds in `delbonds` while there are tokens to unbond. For each bond (a pair of bond start epoch `start` and amount `amount`), it computes how much should be unbonded after slashing (`amount_unbonded_after_slashing`) as follows:
+   - It checks whether some of the tokens in the bond were redelegated and if so computes the total amount of redelegated tokens (`redelegated_amount`).
+   - It computes how much has to be unbonded by taking the minimum between the remainder and the bond amount (`amount_unbonded`).
+   - The protocol prioritizes unbonding first redelegated tokens. Thus, it checks that if the amount to be unbonded is greater than the amount of redelegated tokens
+   - If the amount to be unbonded is greater, then adds `amount_unbonded - redelegated_amount` to `amount_unbonded_after_slashing` after applying any slash that ocurred while the bonded tokens were contributing to the misbehaving validator stake (`start <= slash.epoch`). At this point, the function also updates `total_unbonded`.
+   - Then if some of the tokens in the bond were redelegated, the function proceeds to compute for each of the redelegated bond how much should be unbonded while there remains tokens to be unbonded. For each of the redelegated bonds, the function applies to set of slashes. First, any slash that ocurred while the bonded tokens were contributing to the validator stake (`start <= slash.epoch`). Second, any slash of the source validator of the redelegation such that (i) the redelegation slashing window includes the misbehaving epoch, and (ii) the redelegation bond was contributing to the source validator when this misbehaved.
+   - While iterating over redelegation bonds, the function updates three key variables: `redelegated_bonds`, `total_unbonded_redelegated` and `redelegated_unbonds` if the `unbond` function is not called by a redelegation transaction, i.e., `dest_validator_address=""`, in which case we do not need to record unbonds.
+   - Finally, the function updates the bond by subtracting `amount_unbonded`, registers an unbond if the `unbond` function is not triggered by a redelegation transactions or register the new bond in `redelegated_bonds` otherwise.
+5. It finally updates the validator's `total_deltas` with `amount_after_slashing`, voting power, total voting power and validator sets.
+
 ```go
-/* COMMENT
-  two issues:
-  - https://github.com/informalsystems/partnership-heliax/issues/6
-    delbonds and epoch_counter are considered from the unbonding_length offset.
-    This could lead to scenarios in which one starts unbonding before a bond is materialized.
-    Furthermore, there cannot be positive bonds beyond cur_epoch + pipeline_length, so it does not
-    make sense for delbonds.
-    conclusion: intended
-  - https://github.com/informalsystems/partnership-heliax/issues/7
-    there is a problem with unbonding, slashing and total_deltas becoming negative
-    conclusion: it is an actual issue, unresolved
-*/
-//This function is called by transactions tx_unbond, tx_undelegate and tx_redelegate
-func unbond(validator_address, delegator_address, total_amount, record_unbonds)
+func unbond(validator_address, delegator_address, total_amount, dest_validator_address)
 {
   //disallow unbonding if the validator is frozen
   var frozen = read_epoched_field(validators[validator_address].frozen, cur_epoch, false)
@@ -306,69 +372,62 @@ func unbond(validator_address, delegator_address, total_amount, record_unbonds)
     if (sum{amount | <start, amount> in delbonds} >= total_amount) then
       var remain = total_amount
       var amount_after_slashing = 0
-      //Iterate over bonds and create unbond
+      //iterate over bonds and create unbonds
       forall (<start, amount> in delbonds while remain > 0) do
         //Retrieve the bond's associated redelegation record (if any)
-        var redelegation_record = redelegated_bonds[delegator_address][validator_address][start]
+        var number_redelegations = redelegated_bonds[delegator_address][validator_address][start].size()
         //Take the minimum between the remainder and the unbond. This is equal to amount if remain > amount and remain otherwise 
         var amount_unbonded = min{amount, remain}
         var redelegated_amount = 0
-        if redelegation_record != ⊥ then
-          redelegated_amount = redelegation_record.amount
+        if number_redelegations > 0 then
+          forall (let [validator, redelegation_bonds] of redelegated_bonds[delegator_address][validator_address][start]) do
+            redelegated_amount += sum(redelegation_bonds.values())
 
         var amount_unbonded_after_slashing = 0
+        // set of slashes that happened while the bond was contributing to the validator's stake
+        var set_slashes = {slash | slash in slashes[validator_address] && start <= slash.epoch }
+
         //compute amount after slashing if some of the tokens do not come from redelegation
         if redelegated_amount < amount_unbonded then 
-          // set of slashes that happened while the bond was contributing to the validator's stake
-          var set_slashes = {s | s in slashes[validator_address] && start <= s.epoch }
           amount_unbonded_after_slashing = compute_amount_after_slashing(set_slashes, amount_unbonded - redelegated_amount)
-        //compute amount after slashing  of the tokens coming from redelegation
-        if redelegation_record != ⊥ then
-          set_slashes = set_slashes \union {slash | slash in slashes[redelegation_record.validator] &&
-                                                    //start - pipeline_length is the epoch when the redelegation was issued
-                                                    //any slashed processed at an epoch < slash - pipeline_length - unbonding_length has been applied already
-                                                    start - pipeline_length - unbonding_length <= slash.epoch < start}
-          amount_unbonded_after_slashing += compute_amount_after_slashing(set_slashes, min{redelegated_amount, amount_unbonded})
+          validators[validator_address].total_unbonded[cur_epoch+pipeline_length][start] += amount_unbonded - redelegated_amount
+
+        //compute amount after slashing the tokens coming from redelegation
+        remain -= amount_unbonded - redelegated_amount
+        //initialize unbond_redelegation_record to bottom
+        if number_redelegations > 0 then
+          forall (let [redelegation_validator, redelegation_bonds] of redelegated_bonds[delegator_address][validator_address][start]) do
+            forall (let [red_bond_start, red_bond_amount] of redelegation_bonds while remain > 0) do
+              var final_set_slashes = set_slashes \union {slash | slash in slashes[redelegation_validator] &&
+                                                                  //start - pipeline_length is the epoch when the redelegation was issued
+                                                                  //any slashed processed at an epoch < slash - pipeline_length - unbonding_length has been applied already
+                                                                  start - pipeline_length - unbonding_length <= slash.epoch < start &&
+                                                                  red_bond_start <= slash.epoch}
+              amount_unbonded_after_slashing += compute_amount_after_slashing(final_set_slashes, min{red_bond_amount, remain})
+              redelegated_bonds[delegator_address][validator_address][start][redelegation_validator][red_bond_start] -= min{red_bond_amount, remain}
+              // if it is not a redelegation, then create a redelegated unbond
+              if dest_validator_address != "" then
+                var unbond_end = cur_epoch+pipeline_length+unbonding_length
+                redelegated_unbonds[delegator_address][validator_address][(start, unbond_end)][redelegation_validator][red_bond_start] += min{red_bond_amount, remain}
+                                    
+              validators[validator_address].total_unbonded_redelegated[cur_epoch+pipeline_length][redelegation_validator][(start, red_bond_start)] += min{red_bond_amount, remain}
+
+              remain -= min{red_bond_amount, remain}
 
         amount_after_slashing += amount_unbonded_after_slashing
 
-        //update bond and create new unbond if record_unbonds=true
+        //update bond
         bonds[delegator_address][validator_address].deltas[start] = amount - amount_unbonded
 
-        var end = cur_epoch+pipeline_length+unbonding_length
-        if record_unbonds then
-          unbonds[delegator_address][validator_address].deltas[start, end] = amount_unbonded
+        //if it is a redelegation, then create redelegated bonds at the dest_validator_address
+        //and record the outgoing redelegation at the source validator
+        //if it is not a redelegation, then create unbonds at validator_address and manage redelegated unbonds
+        if dest_validator_address != "" then
+          redelegated_bonds[delegator_address][dest_validator_address][cur_epoch+pipeline_length][src_validator_address][bond_start] += amount
+          validators[validator_address].outgoing_redelegations[dest_validator_address][(start, cur_epoch)] += amount_unbonded_after_slashing
+        else
+          unbonds[delegator_address][validator_address].deltas[start, cur_epoch+pipeline_length+unbonding_length] += amount_unbonded
 
-        //manage redelegation records
-        var redelegation_record_set_unbonds = ⊥
-        if redelegation_record != ⊥ then
-          
-          if record_unbonds then
-            update_unbond_redelegation_record(delegator_address,
-                                              validator_address,
-                                              redelegation_record.validator,
-                                              start,
-                                              end,
-                                              min{redelegation_record.amount, amount_unbonded})
-          if redelegation_record.amount > amount_unbonded then
-            redelegation_record_set_unbonds = Redelegation{validator: redelegation_record.validator, amount: redelegation_record.amount - amount_unbonded}
-            redelegated_bonds[delegator_address][validator_address][start] = redelegation_record_set_unbonds
-          else
-            redelegation_record_set_unbonds = Redelegation{validator: redelegation_record.validator, amount: redelegation_record.amount}
-            redelegated_bonds[delegator_address][validator_address][start] = ⊥
-  
-        //The current model disregards a corner case that should be taken care of in the implementation:
-        //- Assume a user delegates 10 tokens to a validator at epoch e1
-        //- Assume the user unbonds twice 5 tokens from the same validator in the same epoch in two different transactions e2
-        //- When executing the first undelegate tx, the model creates the record UnbondRecord{amount: 5, start: e1} and updates the bond to 5 tokens
-        //- When executing the second undelegate tx, the model creates the same record UnbondRecord{amount: 5, start: e1} and removes the bond.
-        //- The problem is that we keep unbond records in a set and when we try to add the second record, since it is a duplicate, it will be discarded.
-        //It is an easy fix I'd say: use a bag instead of a set to allow duplicates, or check if the set includes the record and act upon
-        //(remove it, create a new one with double the amount, and add it).
-        var unbond_record = UnbondRecord{amount: amount_unbonded, start: start, redelegation: redelegation_record_set_unbonds}
-        validators[validator_address].set_unbonds[cur_epoch+pipeline_length] = {unbond_record} \union validators[validator_address].set_unbonds[cur_epoch+pipeline_length]
-
-        remain -= amount_unbonded
       update_total_deltas(validator_address, pipeline_length, -1*amount_after_slashing)
       update_voting_power(validator_address, pipeline_length)
       update_total_voting_power(pipeline_length)
@@ -377,52 +436,59 @@ func unbond(validator_address, delegator_address, total_amount, record_unbonds)
 }
 ```
 
-```go
-func update_unbond_redelegation_record(delegator_address, src_validator_address, dest_validator_address, start, end, amount)
-{
-  var unbond_redelegation_record = redelegated_unbonds[delegator_address][dest_validator_address][start, end]
-  if (unbond_redelegation_record = ⊥) then
-    var new_record = Redelegation{validator: src_validator_address, amount: amount}
-  else
-    var new_record = Redelegation{validator: src_validator_address, amount: unbond_redelegation_record.amount + amount}
-  redelegated_unbonds[delegator_address][dest_validator_address][start, end] = new_record
-}   
-```
+The `withdraw` function withdraws all tokens unbonded by a delegator `delegator_address` from a validator `validator_address` whose unbonding period has expired. It takes the following steps:
+
+1. It first computes the total amount of tokens that the delegator has unbonded from the validator whose unbonding period has expired.
+2. Then it iterates over the unbonds in `delunbonds`. For each unbond (a triple of bond start epoch `start`, unbond end epoch 'end' and amount `amount`), it computes how much should be withdrawn after slashing (`amount_after_slashing`) as follows:
+   - It checks whether some of the tokens in the unbond were redelegated and if so computes the total amount of redelegated tokens (`redelegated_amount`).
+   - It computes the set of slashes that ocurred while the tokens were contributing to the validator's stake.
+   - Then it computes the how much is left after slashing the non-redelegated chunk of tokens (`amount - redelegated_amount`) after applying the set of slashes previously computed and adds it to `amount_after_slashing`.
+   - If some of the tokens were redelegated, then the function iterates of all redelegations. For each redelegation, it iterates over the redelegation bonds and computes for each redelegation bond how much is left after slashing. The set of slashes applied includes the set set of slashes computed before and any slash of the source validator of the redelegation such that (i) the redelegation slashing window includes the misbehaving epoch, and (ii) the redelegation bond was contributing to the source validator when this misbehaved. Once this is computed, the amount is added to `amount_after_slashing`.
+   - It sets the associated `redelegated_unbonds` entry to 0 to register that those redelegated tokens have been withdrawn.
+3. It transfers `amount_after_slashing` from the PoS account to the delegator's account.
+4. It finally updates `unbonds` to register that the unbonds have been withdrawn.
 
 ```go
 /* COMMENT: Something to check for correctness https://github.com/informalsystems/partnership-heliax/pull/16#discussion_r924319213 */
-//This function is called by transactions tx_withdraw_unbonds_validator and tx_withdraw_unbonds_delegator
 func withdraw(validator_address, delegator_address)
 {
   var delunbonds = {<start,end,amount> | amount = unbonds[delegator_address][validator_address].deltas[(start, end)] > 0 && end <= cur_epoch }
   //substract any pending slash before withdrawing
-  forall (<start,end,amount,redelegation_record> in delunbonds) do
+  forall (<start,end,amount> in delunbonds) do
     //retrieve redelegation record
-    var redelegation_record = redelegated_unbonds[delegator_address][validator_address][start, end]
+    var number_redelegations = redelegated_unbonds[delegator_address][validator_address][(start, end)].size()
     var redelegated_amount = 0
-    if redelegation_record != ⊥ then
-      redelegated_amount = redelegation_record.amount
+    if number_redelegations > 0 then
+      forall (let [validator, redelegation_bonds] of redelegated_unbonds[delegator_address][validator_address][(start, end)]) do
+        redelegated_amount += sum(redelegation_bonds.values())
     // set of slashes that happened while the bond was contributing to the validator's stake
     var set_slashes = {s | s in slashes[validator_address] && start <= s.epoch && s.epoch < end - unbonding_length }
     var amount_after_slashing = compute_amount_after_slashing(set_slashes, amount - redelegated_amount)
-    if redelegation_record != ⊥ then
-      // add slashes if the tokens were redelegated
-      set_slashes = set_slashes \union {slash | slash in slashes[redelegation_record.validator] &&
-                                                //start - pipeline_length is the epoch when the redelegation was issued
-                                                //any slashed processed at an epoch < slash - pipeline_length - unbonding_length
-                                                //has been applied already
-                                                start - pipeline_length - unbonding_length <= slash.epoch < start}
-      amount_after_slashing += compute_amount_after_slashing(set_slashes, redelegated_amount)
+    if number_redelegations > 0 then
+      forall (let [redelegation_validator, redelegation_unbonds] of redelegated_unbonds[delegator_address][validator_address][(start, end)]) do
+        forall (let [red_bond_start, red_bond_amount] of redelegation_unbonds s.t. red_bond_amount > 0) do
+          // add slashes if the tokens were redelegated
+          var final_set_slashes = set_slashes \union {slash | slash in slashes[redelegation_validator] &&
+                                                              //start - pipeline_length is the epoch when the redelegation was issued
+                                                              //any slashed processed at an epoch < slash - pipeline_length - unbonding_length
+                                                              //has been applied already
+                                                              start - pipeline_length - unbonding_length <= slash.epoch < start &&
+                                                              red_bond_start <= slash.epoch}
+          amount_after_slashing += compute_amount_after_slashing(final_set_slashes, red_bond_amount)
+        //manage redelegation records
+        redelegated_unbonds[delegator_address][validator_address][(start, end)][redelegation_validator][red_bond_start] = 0
 
     balance[delegator_address] += amount_after_slashing
     balance[pos] -= amount_after_slashing
     //remove unbond
     unbonds[delegator_address][validator_address].deltas[(start,end)] = 0
-    //manage redelegation records
-    redelegated_unbonds[delegator_address][dest_validator_address][start, end] = ⊥
 
 }
 ```
+The function `compute_amount_after_slashing` applies a set of slashes to a initial stake `amount`. It applies them in slash epoch order as follows:
+
+1. For each `slash`, the function computes the slashable amount: how much of the stake should be slashed due to the infraction. To do so, it first computes how much it is left from initial stake after all slashes ordered before have been applied. This is computed by subtracting from the initial stake the slashable amount of any infraction that was processed before the current infraction (`slash.epoch`).
+2. The returned amount is the initial stake minus the sum of all slashable amounts.
 
 ```go
 func compute_amount_after_slashing(set_slashes, amount) {
@@ -433,11 +499,17 @@ func compute_amount_after_slashing(set_slashes, amount) {
       forall (slashed_amount in computed_amounts s.t. slashed_amount.epoch + unbonding_length < slash.epoch) do
         updated_amount -= slashed_amount.amount
         computed_amounts = computed_amounts \ {slashed_amount}
-      computed_amounts = computed_amounts \union {SlashedAmount{epoch: slash.epoch, amount: updated_amount*slash.rate}}
+      computed_amounts.add(SlashedAmount{epoch: slash.epoch, amount: updated_amount*slash.rate})
 
     return updated_amount - sum({computed_amount.amount | computed_amount in computed_amounts})
 }
 ```
+
+The function `new_evidence` is called when a new infraction is submitted. The function takes the following steps:
+
+1. It first creates a slash record base on the submitted evidence and the schedules the slash to be processed at the end of the epoch resulting from adding `unbonding_length` to the misbehaving epoch.
+2. It jails the validator, removes it from the validator sets, and updates the total voting power.
+3. Finally the function freeze the validator to prevent unbonds from it until the slash is processed.
 
 ```go
 /* COMMENT
@@ -463,6 +535,182 @@ func new_evidence(evidence)
   freeze_validator(validator_address)
 }
 ```
+
+```go
+func compute_stake_fraction(infraction, voting_power){
+  switch infraction
+    case duplicate_vote: return duplicate_vote_rate * voting_power
+    case ligth_client_attack: return ligth_client_attack_rate * voting_power
+    default: panic()
+}
+```
+
+The function `end_of_epoch` is called at the end of every epoch. It takes the following steps:
+
+1. It first computes the slash rate for any slash that has to be processed at the end of the current epoch.
+2. The iterates over the enqueued slashes. For each slash:
+   - It appends the slash to the misbehaving validator's set of slashes.
+   - It uses the `slash_validator` function to slash the misbehaving validator.
+   - It iterates over all validators to which there is an ongoing redelegation from the misbehaving validator. For each destination validator, the function computes the total amount of tokens that are slashable: those belonging to a redelegation for which (i) the redelegation's slashing window includes the misbehaving epoch, and (ii) that were bonded to the the source validator before the misbehaving epoch. If there are tokens to be slashed (`total_amount > 0`), then the function uses `slash_validator` to slash the destination validator.
+3. Finally, it advances the epoch by increasing `cur_epoch`.
+
+```go
+end_of_epoch()
+{
+  //iterate over all slashes for infractions within (-1,+1) epochs range (Step 2.1 of cubic slashing)
+  var set_slashes = {s | s in enqueued_slashes[epoch] && cur_epoch-1 <= epoch <= cur_epoch+1}
+  //calculate the slash rate (Step 2.2 of cubic slashing)
+  var rate = compute_final_rate(set_slashes)
+
+  var set_validators = {val | val = slash.validator && slash in enqueued_slashes[cur_epoch]}
+  forall (validator_address in set_validators) do
+    forall (slash in {s | s in enqueued_slashes[cur_epoch] && s.validator == validator_address}) do
+      //set the slash on the now "finalized" slash amount in storage (Step 2.3 of cubic slashing)
+      slash.rate = rate
+      append(slashes[validator_address], slash)
+      var total_staked = read_epoched_field(validators[validator_address].total_deltas, slash.epoch, 0)
+      
+      slash_validator(validator_address, slash, total_staked, "")
+
+      forall (dest_validators in validators[validator_address].outgoing_redelegations.keys()) do
+        var total_amount = 0
+        var redelegations = validators[validator_address].outgoing_redelegations[dest_validators].entries()
+        // selects all outgoing redelegations issued within the redelegation window defined by slash.epoch
+        // and whose tokens were contributing the source validator when this misbehaved 
+        forall (let [(bond_start, redelegation_start), amount] of redelegations s.t. amount > 0 &&
+                                                                      redelegation_start - unbonding_length <= slash.epoch < redelegation_start + pipeline_length &&
+                                                                      bond_start <= slash.epoch) do
+          total_amount += amount
+        if total_amount > 0 then 
+          slash_validator(dest_validators, slash, total_amount, validator_address)
+
+    //unfreeze the validator (Step 2.5 of cubic slashing)
+    //this step is done in advance when the evidence is found
+    //by setting validators[validator_address].frozen[cur_epoch+unbonding_length+1]=false
+    //note that this index could have been overwritten if more evidence for the same validator
+    //where found since then
+  cur_epoch = cur_epoch + 1
+}
+```
+
+The `slash_validator` function is called by the `end_of_epoch` function for a given validator `validator_address`, slash `slash` and amount `staked_amount`, which is the stake that must be slashed. The function also includes a fourth parameter `src_validator` that it is only assigned (`!=""`) if the validator is slashed because the source validator of a redelegation misbehaved. In that case `src_validator` indicates the address of the misbehaving validator. The function proceeds as follows:
+
+1. It first computes `total_unbonded` up to the cur_epoch: the total amount of tokens from `staked_amount` that have been unbonded by `cur_epoch`. For each epoch from the misbehaving epoch (`slash.epoch`) up to `cur_epoch`, the function uses `compute_total_unbonded` or `compute_total_unbonded_redelegated` to compute the total amount of tokens unbonded in that epoch depending on whether `validator_address` is slashed due to a redelegation or not.
+2. Then for each `epoch` from `cur_epoch` to `cur_epoch+pipeline_length`, the function updates the validator's `total_deltas` and voting power by taking the following steps:
+     - Add the amount of tokens from `staked_amount` that have been unbonded at `epoch` to `total_unbonded`.
+     - Compute how much we should slash in `this_slash`.
+     - Since `update_total_deltas` updates the validator's `total_deltas` from given epoch `cur_epoch+offset` up to `cur_epoch+unbonding_length`, we may over slash in cases when tokens are unbonded at higher epochs. For instance, assume that we slash `X` tokens at epoch `e`. Then, we take `X` tokens from `total_deltas` at `e+1` when calling `update_total_deltas`. If the validator unbonded `Y <= X` of those `X` tokens at `e+1`, we need to add `Y` tokens to `total_deltas` at `e+1` when iterating over `e+1`.  `last_slash - this_slash` compensates for that.
+     - Finally, the function updates the validator's `total_deltas` and voting power by calling `update_total_deltas` and `update_voting_power`.
+
+```go
+func slash_validator(validator_address, slash, staked_amount, src_validator)
+{
+  var total_unbonded = 0
+  //find the total unbonded from the slash epoch up to the current epoch first
+  //a..b notation determines an integer range: all integers between a and b inclusive
+  forall (epoch in slash.epoch+1..cur_epoch) do
+    if (src_validator == "") then
+      total_unbonded += compute_total_unbonded(validator_address, slash, epoch)
+    else
+      total_unbonded += compute_total_unbonded_redelegated(validator_address, src_validator, slash, epoch)
+
+  var last_slash = 0
+  // up to pipeline_length because there cannot be any unbond in a greater epoch (cur_epoch+pipeline_length is the upper bound)
+  forall (offset in 1..pipeline_length) do
+    if (src_validator == "") then
+      total_unbonded += compute_total_unbonded(validator_address, slash, cur_epoch+offset)
+    else
+      total_unbonded += compute_total_unbonded_redelegated(validator_address, src_validator, slash, cur_epoch+offset)
+
+    var this_slash = (staked_amount - total_unbonded) * slash.rate
+    var diff_slashed_amount = last_slash - this_slash
+    last_slash = this_slash
+    update_total_deltas(validator_address, offset, diff_slashed_amount)
+    update_voting_power(validator_address, offset)
+}
+```
+
+The `compute_total_unbonded` function computes `total_unbonded` for a given epoch `epoch`, slash `slash` and validator `validator_address`.
+The function computes `total_unbonded` in two steps: first considers exclusively non-redelegated tokens, i.e., those delegated directly to the validator, and then tokens that were redelegated. In more detail:
+
+1. It iterates over the non-redelegated tokens unbonded in `epoch` (`validators[validator_address].total_unbonded[epoch]`) that were contributing to the validator's stake when this misbehaved (at `slash.epoch`).
+   - At each iteration, it adds the amount unbonded to `total_unbonded` after applying any slash that was processed before `slash.epoch`.
+2. The second step consists in adding to `total_unbonded` any amount of tokens, which belong to a redelegation, that were unbonded at `epoch`.
+   - This only includes redelegations that ended before the misbehaving epoch, i.e., `red_start <= slash.epoch`. Otherwise, those tokens would not have contributed to the misbehaving validator's stake when this misbehaved, so we would not need to add them to `total_unbonded`.
+   - For each of those redelegations, we first compute the set of slashes for any infractions committed by the misbehaving validator that was processed before `slash.epoch`.
+   - Finally, for each of the bonds belonging to a redelegation, the function adds to the above set of slashes any slash for an infraction committed by the redelegation's source validator that (i) was processed before `slash.epoch`, (ii) the redelegation slashing window includes the misbehaving epoch, and (iii) the bonds were contributing to the source validator when this misbehaved. The function then adds the amount to `total_unbonded` after slashing it with the computed set of slashes.
+
+```go
+func compute_total_unbonded(validator_address, slash, epoch){
+  var total_unbonded = 0
+  //select the epochs (start_epochs) at which bonds contributing to the misbehaving validator
+  //were unbonded at epoch
+  var start_epochs = { start | start in validators[validator_address].total_unbonded[epoch].keys() &&
+                               validators[validator_address].total_unbonded[epoch][start] > 0 &&
+                               start <= slash.epoch }
+  //add those tokens to total_unbonded after slashing
+  forall (start in start_epochs)
+    //the set of slashes only includes those that were processed before slash.epoch: s.epoch + unbonding_length < slash.epoch
+    var set_slashes = {s | s in slashes[validator_address] &&
+                       start <= s.epoch &&
+                       s.epoch + unbonding_length < slash.epoch }
+    total_unbonded += compute_amount_after_slashing(set_slashes, validators[validator_address].total_unbonded[epoch][start])
+
+  forall (let [(red_start, redelegation_validator), redelegation_bonds] of validators[validator_address].total_unbonded_redelegated[epoch] s.t. red_start <= slash.epoch) do
+    var set_slashes = {s | s in slashes[validator_address] &&
+                       red_start <= s.epoch &&
+                       s.epoch + unbonding_length < slash.epoch }
+    //iterate over all redelegated tokens that were unbonded at epoch and that were contributing to the misbehaving validators stake at slash.epoch
+    forall (let [red_bond_start, red_bond_amount] of redelegation_bonds s.t. red_bond_amount > 0) do
+      //apply the set of slashes including those that were processed before slash.epoch: s.epoch + unbonding_length < slash.epoch and that
+      //were not processed when the redelegation ocurred: red_start - pipeline_length - unbonding_length <= s.epoch < red_start
+      var final_set_slashes = set_slashes \union {s | s in slashes[redelegation_validator] &&
+                                                    red_start - pipeline_length - unbonding_length <= s.epoch < red_start &&
+                                                    s.epoch + unbonding_length < slash.epoch &&
+                                                    red_bond_start < s.epoch}
+      total_unbonded += compute_amount_after_slashing(final_set_slashes, red_bond_amount)
+  return total_unbonded
+}
+```
+
+The `compute_total_unbonded_redelegated` function computes `total_unbonded` for a given epoch `epoch`, slash `slash`, validator `validator_address`, and source validator `src_validator` (the misbehaving validator).
+The function computes `total_unbonded` in as follows:
+
+1. It first selects from of all redelegated tokens unbonded at `epoch` those that were redelegated (i) by `src_validator`, and (ii) the redelegation slashing window includes the misbehaving epoch (`slash.epoch`).
+2. Then it iterates over all of the selected redelegations. For each redelegation, it iterates over all bonds (`> 0`) that were contributing to the misbehaving validator `src_validator` when it misbehaved (at `slash.epoch`).
+3. For each of the iterated bonds, the function applies any slash that (i) falls within the associated redelegation slashing window and that was processed before `slash.epoch`. Note that it is unclear at the moment if this is possible given the size of the redelegation slashing window and the constraint that it has to be processed before `slash.epoch`.
+
+```go
+func compute_total_unbonded_redelegated(validator_address, src_validator, slash, epoch){
+  var total_unbonded = 0
+  //only consider unbonded tokens that were redelegated by the misbehaving validator
+  var redelegations = validators[validator_address].total_unbonded_redelegated[epoch].entries()
+  forall (let [(red_start, redelegation_validator), redelegation_bonds] of redelegations s.t. redelegation_validator == src_validator &&
+                                                                                              red_start - unbonding_length - pipeline_length <= slash.epoch < red_start) do
+    forall (let [red_bond_start, red_bond_amount] of redelegation_bonds s.t. red_bond_start <= slash.epoch && red_bond_amount > 0) do
+      //apply any slash to red_bond_amount processed before slash.epoch and that was not already applied when the redelegation was created
+      //TODO: check that this set is not always empty
+      var set_slashes = {s | s in slashes[validator_address] &&
+                             red_start - unbonding_length - pipeline_length <= s.epoch &&
+                             s.epoch + unbonding_length < slash.epoch}
+
+      total_unbonded += compute_amount_after_slashing(set_slashes, red_bond_amount)
+  return total_unbonded
+}
+```
+
+```go
+//Cubic slashing function
+compute_final_rate(slashes)
+{
+  var voting_power_fraction = 0
+  forall (slash in slashes) do
+    voting_power_fraction += slash.voting_power_fraction
+  return max{0.01, min{1, voting_power_fraction^2 * 9}}
+}
+```
+
+### Validator's functions
 
 ```go
 add_validator_to_sets(validator_address, offset)
@@ -549,7 +797,7 @@ func update_validator_sets(validator_address, offset)
     var sets = read_epoched_field(validator_sets, epoch, ⊥)
     var min_active = first(sets.active)
     var max_inactive = last(sets.inactive)
-    power_before = get(sets.active U sets.active, validator_address).voting_power
+    power_before = get(sets.active U sets.inactive, validator_address).voting_power
     power_after = read_epoched_field(validators[validator_address].voting_power, epoch, 0)
     if (power_before >= max_inactive.voting_power) then
       //if active but it loses power below the max_inactive then move validator to inactive
@@ -599,170 +847,13 @@ func is_validator(validator_address, epoch){
 ```
 
 ```go
-func compute_stake_fraction(infraction, voting_power){
-  switch infraction
-    case duplicate_vote: return duplicate_vote_rate * voting_power
-    case ligth_client_attack: return ligth_client_attack_rate * voting_power
-    default: panic()
-}
-```
-
-```go
-end_of_epoch()
-{
-  //iterate over all slashes for infractions within (-1,+1) epochs range (Step 2.1 of cubic slashing)
-  var set_slashes = {s | s in enqueued_slashes[epoch] && cur_epoch-1 <= epoch <= cur_epoch+1}
-  //calculate the slash rate (Step 2.2 of cubic slashing)
-  var rate = compute_final_rate(set_slashes)
-
-  var set_validators = {val | val = slash.validator && slash in enqueued_slashes[cur_epoch]}
-  forall (validator_address in set_validators) do
-    forall (slash in {s | s in enqueued_slashes[cur_epoch] && s.validator == validator_address}) do
-      //set the slash on the now "finalized" slash amount in storage (Step 2.3 of cubic slashing)
-      slash.rate = rate
-      append(slashes[validator_address], slash)
-      var total_staked = read_epoched_field(validators[validator_address].total_deltas, slash.epoch, 0)
-      slash_misbehaving_validator(validator_address, slash, total_staked)
-
-      forall (dest_validators in validators[validator_address].outgoing_redelegations.keys()) do
-        forall (amount in {amount | amount = validators[validator_address].outgoing_redelegations[dest_validators][start] > 0 &&
-                                             start - unbonding_length <= slash.epoch < start + pipeline_length}) do
-          slash_redelegated_validator(dest_validators, validator_address, slash, amount)
-
-    //unfreeze the validator (Step 2.5 of cubic slashing)
-    //this step is done in advance when the evidence is found
-    //by setting validators[validator_address].frozen[cur_epoch+unbonding_length+1]=false
-    //note that this index could have been overwritten if more evidence for the same validator
-    //where found since then
-  cur_epoch = cur_epoch + 1
-}
-```
-
-```go
-func slash_misbehaving_validator(src_validator_address, dest_validator_address, slash, total_staked)
-{
-  var total_unbonded = 0
-  //find the total unbonded from the slash epoch up to the current epoch first
-  //a..b notation determines an integer range: all integers between a and b inclusive
-  forall (epoch in slash.epoch+1..cur_epoch) do
-    forall (unbond in validators[validator_address].set_unbonds[epoch] s.t. unbond.start <= slash.epoch)
-
-      //retrieve redelegation record
-      var redelegation_record = unbond.redelegation
-      var redelegated_amount = 0
-      if redelegation_record != ⊥ then
-        redelegated_amount = redelegation_record.amount
-      // set of slashes that happened while the bond was contributing to the validator's stake
-      // We only need to apply a slash s if s.epoch < unbond.end - unbonding_length
-      // It is easy to see that s.epoch + unbonding_length < slash.epoch implies s.epoch < unbond.end - unbonding_length
-      // 1) slash.epoch = cur_epoch - unbonding_length
-      // 2) unbond.end = cur_epoch + offset + unbonding_length => cur_epoch = unbond.end - offset - unbonding_length
-      // By 1) s.epoch + unbonding_length < cur_epoch - unbonding_length
-      // By 2) s.epoch + unbonding_length < unbond.end - offset - 2*unbonding_length => s.epoch < unbond.end - offset - 3*unbonding_length, as required.
-      var set_slashes = {s | s in slashes[validator_address] &&
-                             unbond.start <= s.epoch &&
-                             s.epoch + unbonding_length < slash.epoch }
-     total_unbonded += compute_amount_after_slashing(set_slashes, unbond.amount - redelegated_amount)
-      if redelegation_record != ⊥ then
-        // add slashes if the tokens were redelegated
-        set_slashes = set_slashes \union {s | s in slashes[redelegation_record.validator] &&
-                                              //unbond.start - pipeline_length is the epoch when the redelegation was issued
-                                              //any slashed processed at an epoch < unbond.start - pipeline_length has
-                                              //been applied already, so we ignore them.
-                                              //a slash with epoch e is processed at e + unbonding_length, we should then consider slashes
-                                              //such that slash.epoch + unbonding_length >= unbond.start - pipeline_length
-                                              unbond.start - pipeline_length - unbonding_length <= s.epoch < unbond.start &&
-                                              //slash s is processed before the misbehaving epoch (slash.epoch)
-                                              s.epoch + unbonding_length < slash.epoch}
-        total_unbonded += compute_amount_after_slashing(set_slashes, redelegated_amount)
-
-  var last_slash = 0
-  // up to pipeline_length because there cannot be any unbond in a greater ß (cur_epoch+pipeline_length is the upper bound)
-  forall (offset in 1..pipeline_length) do
-    forall (unbond in validators[validator_address].set_unbonds[cur_epoch + offset] s.t. unbond.start <= slash.epoch) do
-
-      //retrieve redelegation record
-      var redelegation_record = unbond.redelegation
-      var redelegated_amount = 0
-      if redelegation_record != ⊥ then
-        redelegated_amount = redelegation_record.amount
-      // set of slashes that happened while the bond was contributing to the validator's stake
-      var set_slashes = {s | s in slashes[validator_address] &&
-                              unbond.start <= s.epoch &&
-                              s.epoch + unbonding_length < slash.epoch }
-      var total_unbonded = compute_amount_after_slashing(set_slashes, unbond.amount - redelegated_amount)
-      if redelegation_record != ⊥ then
-        // add slashes if the tokens were redelegated
-        set_slashes = set_slashes \union {s | s in slashes[redelegation_record.validator] &&
-                                              unbond.start - pipeline_length - unbonding_length <= s.epoch < unbond.start &&
-                                              s.epoch + unbonding_length < slash.epoch}
-        total_unbonded += compute_amount_after_slashing(set_slashes, redelegated_amount)
-
-    var this_slash = (total_staked - total_unbonded) * slash.rate
-    var diff_slashed_amount = last_slash - this_slash
-    last_slash = this_slash
-    update_total_deltas(validator_address, offset, diff_slashed_amount)
-    update_voting_power(validator_address, offset)
-}
-```
-
-```go
-func slash_redelegated_validator(validator_address, src_validator, slash, staked_amount)
-{
-  var total_unbonded = 0
-  //find the total unbonded from the slash epoch up to the current epoch first
-  //a..b notation determines an integer range: all integers between a and b inclusive
-  forall (epoch in slash.epoch+1..cur_epoch) do
-    //filter those unbonds that were contributing to the stake when the validator misbehaved
-    forall (unbond in validators[validator_address].set_unbonds[epoch] s.t. unbond.start - unbonding_length - pipeline_length <= slash.epoch && 
-                                                                            unbond.redelegation != ⊥ &&
-                                                                            unbond.redelegation.validator == src_validator) do
-      //TODO: check that this set is not always empty
-      var set_slashes = {s | s in slashes[validator_address] &&
-                             unbond.start - unbonding_length - pipeline_length <= s.epoch &&
-                             s.epoch + unbonding_length < slash.epoch }
-
-      total_unbonded += compute_amount_after_slashing(set_slashes, unbond.amount)
-
-  var last_slash = 0
-  // up to pipeline_length because there cannot be any unbond in a greater ß (cur_epoch+pipeline_length is the upper bound)
-  forall (offset in 1..pipeline_length) do
-    forall (unbond in validators[validator_address].set_unbonds[cur_epoch + offset] s.t. unbond.start - unbonding_length - pipeline_length <= slash.epoch && 
-                                                                                         unbond.redelegation != ⊥ &&
-                                                                                         unbond.redelegation.validator == src_validator) do
-
-      //TODO: check that this set is not always empty
-      var set_slashes = {s | s in slashes[validator_address] &&
-                             unbond.start - unbonding_length - pipeline_length <= s.epoch &&
-                             s.epoch + unbonding_length < slash.epoch }
-      total_unbonded += compute_amount_after_slashing(set_slashes, unbond.amount)
-    var this_slash = (staked_amount - total_unbonded) * slash.rate
-    var diff_slashed_amount = last_slash - this_slash
-    last_slash = this_slash
-    update_total_deltas(validator_address, offset, diff_slashed_amount)
-    update_voting_power(validator_address, offset)
-}
-```
-
-```go
-//Cubic slashing function
-compute_final_rate(slashes)
-{
-  var voting_power_fraction = 0
-  forall (slash in slashes) do
-    voting_power_fraction += slash.voting_power_fraction
-  return max{0.01, min{1, voting_power_fraction^2 * 9}}
-}
-```
-
-```go
 is_jailed(validator_address)
 {
   return validators[validator_address].jail_record.is_jailed
 }
 ```
 
-## Auxiliary functions
+### Auxiliary functions
 
 ```go
 func read_epoched_field(field, upper_epoch, bottom){


### PR DESCRIPTION
This PR adds redelegation to the pseudocode model and English text to describe the main logic and some definitions.

Note that the text below may be a bit outdatet.

### Definitions
- We use source and destination validators to refer to the validator from which the tokens are redelegation and the validator to which the tokens are redelegated respectively.
- We say that a redelegation starts the epoch at which the `tx_redelegate` tx is issued and ends when the redelegated tokens stop contributing to the source validator and start contributing to the destination validator.
- Chain redelegations occur when some redelegated tokens are redelegated within less than `unbonding_length` epochs.

### Desired Properties
The solution aim to guarantee the following desired properties:
- **Fast redelegation**: Redelegated tokens start contributing to the destination validator stake after `pipeline_length` epochs. This means that if a delegator redelegates X tokens at epoch `e`, then these tokens stop contributing to the source validator stake and start contributing to the destination validator stake at `e+pipeline_length`.
- **Minimize changes**: Adding redelegation should not require a major redesign of the existing protocol.

### Data Structures
The solution introduces the following data structures to track redelegations:
- `Redelegation` is a record with two fields: the source validator and the amount of tokens redelegated.
- `redelegated_bonds in (Addr X Addr X Epoch) → Redelegation`: A map from delegator to a map from redelegation's destination validator to a map from the epoch at which the redelegation ends to a Redelegation record. This sounds more complex than it is. This is accessed by simply `redelegated_bonds[delegator][dest_validator][epoch]`. It is the counterparty of the `bonds` data structure. 
- `redelegated_unbonds[][][] in (Addr X Addr X (Epoch, Epoch)) → Redelegation`: Similar to `redelegated_bonds` but the key of the last map is a tuple to track not only the end of the redelegation but also the when the tokens are unbonded at the destination validator. It is the counterparty of the `unbonds` data structure.
- Each validator now keeps track of incoming validators in a map: `redelegations map<Addr, map<Addr, IncomingRedelegation>>`. This is useful to prevent redelegations. `IncomingRedelegation` is a record that stores the amount redelegated and the epoch at which the redelegation started.

### How it roughly works
- The main complexity comes from the fact that we do not keep a separate record for each bond/unbond but we accumulate them per epoch (epochs for unbonds) in a delta data structure. This makes things complicated because when slashing we need to know the precise amount of tokens that come from a redelegation to be able to apply slashes of the source validator if required. `redelegated_bonds` and `redelegated_unbonds` aim at solving this issue. Let's take the following example:
  - Assume a delegator `del`  and two validators `val1` and `val2`.
  - `del` redelegates X tokens from `val1` to `val2` in epoch `e`. Then the redelegation ends at `e + pipeline_length`. Then `bonds[del][val2].deltas[e+pipeline_length]=X`, assuming that there were no bonds before.
  - `del` delegates `Y` tokens to `val2` in epoch `e` as well. Then `bonds[del][val2].deltas[e+pipeline_length]=X+Y`.
  - Assume now that `del` want to unbond at an epoch `e' >= e+pipeline_length` and the bonds in `bonds[del][val2].deltas[e+pipeline_length]` are going to be unbonded. We need to do two things:
    - Apply all slashes processed by `e'` that `val2` committed in any epoch ` >= e+ pipeline_length` to the whole amount (X+Y).
    - Also, we need to apply any slashes that the source validator committed while the Y tokens were being redelegated (any slash not processed before the redelegation started and committed before the redelegation ends.
  - To compute X and Y precisely, the solution relies on `redelegated_bonds`. Thus:
    - `bonds[del][val2].deltas[e+pipeline_length]=X+Y`
    - `redelegated_bonds[del][val2][e+pipeline_length]=Y`
    - X can be computed from the above.
- The above logic has to be applied not only on unbonding, but also when withdrawing and at the end of an epoch when a validator is slashed.
- Other details:
  - When we redelegate tokens, we do not just simply move the bond amounts to the destination validator, but we slash first. Thus, the bonded amount at the destination validator already accounts for all the slashes committed by the source validator processed before the redelegation starts. This means that we only need to care about slashes of the source validator that were processed after the redelegation started and before it ended (at that point, the tokens do not contribute to the source validator stake).
  - Another tricky part is what happens at the end of an epoch. We first need to slash the misbehaving validator. Then we have to slash any validator for which the misbehaving validator redelegated tokens to. Slashes are always filtered based on when the infraction was committed and when the redelegation started/ended.
