### PR TITLE
Quint spec Namada without redelegation

### DIFF
--- a/2023/Q2/artifacts/PoS-quint/basicSpells.qnt
+++ b/2023/Q2/artifacts/PoS-quint/basicSpells.qnt
@@ -1,0 +1,112 @@
+// -*- mode: Bluespec; -*-
+/**
+ * This module collects definitions that are ubiquitous.
+ * One day they will become the standard library of Quint.
+ */
+module basicSpells {
+  /// An annotation for writing preconditions.
+  /// - @param __cond condition to check
+  /// - @returns true if and only if __cond evaluates to true
+  pure def require(__cond: bool): bool = __cond
+
+  run requireTest = all {
+    assert(require(4 > 3)),
+    assert(not(require(false))),
+  }
+
+  /// A convenience operator that returns a string error code,
+  ///  if the condition does not hold true.
+  ///
+  /// - @param __cond condition to check
+  /// - @param __error a non-empty error message
+  /// - @returns "", when __cond holds true; otherwise __error
+  pure def requires(__cond: bool, __error: str): str = {
+    if (__cond) "" else __error
+  }
+
+  run requiresTest = all {
+    assert(requires(4 > 3, "4 > 3") == ""),
+    assert(requires(4 < 3, "false: 4 < 3") == "false: 4 < 3"),
+  }
+
+
+  /// Compute the maximum of two integers.
+  ///
+  /// - @param __i first integer
+  /// - @param __j second integer
+  /// - @returns the maximum of __i and __j
+  pure def max(__i: int, __j: int): int = {
+    if (__i > __j) __i else __j
+  }
+
+  run maxTest = all {
+    assert(max(3, 4) == 4),
+    assert(max(6, 3) == 6),
+    assert(max(10, 10) == 10),
+    assert(max(-3, -5) == -3),
+    assert(max(-5, -3) == -3),
+  }
+
+  /// Remove a set element.
+  ///
+  /// - @param __set a set to remove an element from
+  /// - @param __elem an element to remove
+  /// - @returns a new set that contains all elements of __set but __elem
+  pure def setRemove(__set: Set[a], __elem: a): Set[a] = {
+    __set.exclude(Set(__elem))
+  }
+
+  run setRemoveTest = all {
+    assert(Set(2, 4) == Set(2, 3, 4).setRemove(3)),
+    assert(Set() == Set().setRemove(3)),
+  }
+
+  /// Test whether a key is present in a map
+  ///
+  /// - @param __map a map to query
+  /// - @param __key the key to look for
+  /// - @returns true if and only __map has an entry associated with __key
+  pure def has(__map: a -> b, __key: a): bool = {
+    __map.keys().contains(__key)
+  }
+
+  run hasTest = all {
+    assert(Map(2 -> 3, 4 -> 5).has(2)),
+    assert(not(Map(2 -> 3, 4 -> 5).has(6))),
+  }
+
+  /// Get the map value associated with a key, or the default,
+  /// if the key is not present.
+  ///
+  /// - @param __map the map to query
+  /// - @param __key the key to search for
+  /// - @returns the value associated with the key, if __key is
+  ///   present in the map, and __default otherwise
+  pure def getOrElse(__map: a -> b, __key: a, __default: b): b = {
+    if (__map.has(__key)) {
+      __map.get(__key)
+    } else {
+      __default
+    }
+  }
+
+  run getOrElseTest = all {
+    assert(Map(2 -> 3, 4 -> 5).getOrElse(2, 0) == 3),
+    assert(Map(2 -> 3, 4 -> 5).getOrElse(7, 11) == 11),
+  }
+
+  /// Remove a map entry.
+  ///
+  /// - @param __map a map to remove an entry from
+  /// - @param __key the key of an entry to remove
+  /// - @returns a new map that contains all entries of __map
+  ///          that do not have the key __key
+  pure def mapRemove(__map: a -> b, __key: a): a -> b = {
+    __map.keys().setRemove(__key).mapBy(__k => __map.get(__k))
+  }
+
+  run mapRemoveTest = all {
+    assert(Map(3 -> 4, 7 -> 8) == Map(3 -> 4, 5 -> 6, 7 -> 8).mapRemove(5)),
+    assert(Map() == Map().mapRemove(3)),
+  }
+}

--- a/2023/Q2/artifacts/PoS-quint/manuSpells.qnt
+++ b/2023/Q2/artifacts/PoS-quint/manuSpells.qnt
@@ -7,12 +7,12 @@ module manuSpells {
 
   import basicSpells.* from "./basicSpells"
 
-  /// Remove a map entry.
+  /// Safely set a map entry.
   ///
-  /// - @param __map a map to remove an entry from
-  /// - @param __key the key of an entry to remove
+  /// - @param __map a map to set an entry to
+  /// - @param __key the key of an entry to set
   /// - @returns a new map that contains all entries of __map
-  ///          that do not have the key __key
+  ///          and an entry for the key __key
   pure def safeSet(__map: a -> b, __key: a, __value: b): a -> b = {
     if (__map.has(__key)) {
       __map.set(__key, __value)
@@ -24,5 +24,35 @@ module manuSpells {
   run safeSetTest = all {
     assert(Map(2 -> 3, 4 -> 5).safeSet(1, 7) == Map(1 -> 7, 2 -> 3, 4 -> 5)),
     assert(Map(2 -> 3, 4 -> 5).safeSet(2, 7) == Map(2 -> 7, 4 -> 5))
+  }
+
+  /// Compute the minimum of two integers.
+  ///
+  /// - @param __i first integer
+  /// - @param __j second integer
+  /// - @returns the minimum of __i and __j
+  pure def min(__i: int, __j: int): int = {
+    if (__i > __j) __j else __i
+  }
+
+  run minTest = all {
+    assert(min(3, 4) == 3),
+    assert(min(6, 3) == 3),
+    assert(min(10, 10) == 10),
+    assert(min(-3, -5) == -5),
+    assert(min(-5, -3) == -5),
+  }
+
+  /// Add a set element.
+  /// - @param __set a set to add an element to
+  /// - @param __elem an element to add
+  /// - @returns a new set that contains all elements of __set and __elem
+  pure def setAdd(__set: Set[a], __elem: a): Set[a] = {
+    __set.union(Set(__elem))
+  }
+
+  run setAddTest = all {
+    assert(Set(2, 3, 4, 5) == Set(2, 3, 4).setAdd(5)),
+    assert(Set(3) == Set(3).setAdd(3)),
   }
 }

--- a/2023/Q2/artifacts/PoS-quint/manuSpells.qnt
+++ b/2023/Q2/artifacts/PoS-quint/manuSpells.qnt
@@ -1,0 +1,28 @@
+// -*- mode: Bluespec; -*-
+/**
+ * This module collects definitions that are ubiquitous.
+ * One day they will become the standard library of Quint.
+ */
+module manuSpells {
+
+  import basicSpells.* from "./basicSpells"
+
+  /// Remove a map entry.
+  ///
+  /// - @param __map a map to remove an entry from
+  /// - @param __key the key of an entry to remove
+  /// - @returns a new map that contains all entries of __map
+  ///          that do not have the key __key
+  pure def safeSet(__map: a -> b, __key: a, __value: b): a -> b = {
+    if (__map.has(__key)) {
+      __map.set(__key, __value)
+    } else {
+      __map.keys().union(Set(__key)).mapBy(__k => if (__k == __key) __value else __map.get(__k))
+    }
+  }
+
+  run safeSetTest = all {
+    assert(Map(2 -> 3, 4 -> 5).safeSet(1, 7) == Map(1 -> 7, 2 -> 3, 4 -> 5)),
+    assert(Map(2 -> 3, 4 -> 5).safeSet(2, 7) == Map(2 -> 7, 4 -> 5))
+  }
+}

--- a/2023/Q2/artifacts/PoS-quint/namada.qnt
+++ b/2023/Q2/artifacts/PoS-quint/namada.qnt
@@ -178,7 +178,7 @@ module namada {
     * 4. It increases the validator's stake.
     */
     pure def delegate(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState, amount: int): ResultTx = {
-      if (amount <= delegatorState.balance) {
+      if (amount <= delegatorState.balance and amount > 0) {
         val updatedDelegatorState = delegatorState.with("balance", delegatorState.balance - amount)
                                                   .with("bonded", delegatorState.bonded.set(validatorState.address,
                                                                                             addRecord(delegatorState.bonded.get(validatorState.address),
@@ -212,7 +212,7 @@ module namada {
                                                   .with("unbonded", delegatorState.unbonded.set(validatorState.address, delegatorState.unbonded.get(validatorState.address).union(newUnbonds)))                                  
         val amountAfterSlashing = newUnbonds.fold(0, (sum, element) => val listSlashes = validatorState.slashes.select(slash => element.start <= slash.epoch)
                                                                        sum + applyListSlashes(listSlashes, element.amount))
-        val updatedTotalUnbonded = newUnbonds.fold(validatorState.totalUnbonded.get(posState.epoch),
+        val updatedTotalUnbonded = newUnbonds.fold(validatorState.totalUnbonded.get(posState.epoch + PIPELINE_OFFSET),
                                                    (acc, element) => acc.safeSet(element.start, acc.getOrElse(element.start, 0) + element.amount))
         val updatedValidatorState = validatorState.with("stake", validatorState.stake.set(posState.epoch + PIPELINE_OFFSET,
                                                                                           validatorState.stake.get(posState.epoch + PIPELINE_OFFSET) - amountAfterSlashing))
@@ -257,7 +257,7 @@ module namada {
     }
 
     pure def slashValidator(initMap: Epoch -> int, curEpoch: Epoch, stake: int, slash: Slash, prevSlashes: List[Slash], totalUnbonded: Epoch -> Epoch -> int, finalRate: int): Epoch -> int = {
-      val initTotalUnbonded = slash.epoch.to(curEpoch).fold(0, (sum, e) => sum + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e)))
+      val initTotalUnbonded = (slash.epoch+1).to(curEpoch).fold(0, (sum, e) => sum + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e)))
       val result = (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).fold((initTotalUnbonded, initMap), (acc, e) => val updatedTotalUnbonded = acc._1 + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e))
                                                                                                             val slashedAmount = (stake - updatedTotalUnbonded) * finalRate
                                                                                                             (updatedTotalUnbonded, acc._2.set(e, acc._2.get(e) + slashedAmount)))
@@ -297,9 +297,9 @@ module namada {
 
     pure def proccessEvidence(e: Epoch, validatorState: ValidatorState, posState: PosState): {validatorState: ValidatorState, posState: PosState} = {
       val nextSlashCounter = posState.counterSlashes + 1
-      val slash = {id: posState.counterSlashes + 1, epoch: e, validator: validatorState.address, rate: 1}
+      val slash = {id: nextSlashCounter, epoch: e, validator: validatorState.address, rate: 1}
       {validatorState: validatorState.with("frozen", max(validatorState.frozen, e + UNBONDING_OFFSET)),
-       posState: posState.with("counterSlashes", posState.counterSlashes + 1)
+       posState: posState.with("counterSlashes", nextSlashCounter)
                          .with("enqueuedSlashes", posState.enqueuedSlashes.set(e + UNBONDING_OFFSET, posState.enqueuedSlashes.get(e + UNBONDING_OFFSET).union(Set(slash))))}
     }
 
@@ -360,7 +360,8 @@ module namada {
     }
 
     action actionEvidence(e: Epoch, validator: Address): bool = all {
-      if (limitEvidence) require(validators.get(validator).frozen < e) else true,
+      //if (limitEvidence) require(validators.get(validator).frozen < e) else true,
+      require(limitEvidence implies validators.get(validator).frozen < e),
       val result = proccessEvidence(e, validators.get(validator), pos)
       all {
         validators' = validators.set(validator, result.validatorState),
@@ -374,33 +375,45 @@ module namada {
     * Invariants
     * ************************************************************************* */
 
-    // Invariant 1: The total amount of tokens is constant.
-    val totalAmountTokensConstant = USERS.fold(0, (sum, user) => sum + delegators.get(user).balance) + pos.posAccount + pos.slashPool== size(USERS)*INIT_BALANCE
-
-    // Invariant 2: A delegator's balance cannot become negative.
+    // Invariant 1: A delegator's balance cannot become negative.
     val balanceGreaterZero = USERS.forall(user => delegators.get(user).balance >= 0)
 
-    // Invariant 3: A validator's stake cannot become negative.
+    // Invariant 2: The PoS account cannot become negative.
+    val posAccountGreaterZero = pos.posAccount >= 0
+
+    // Invariant 3: If there are no bonds and all unbonds have been withdrawn, the PoS balance must be equal to zero.
+    val posAccountZero = USERS.forall(user => VALIDATORS.forall(validator => delegators.get(user).bonded.get(validator) == Set() and
+                                                                             delegators.get(user).unbonded.get(validator) == Set())) implies pos.posAccount == 0
+
+    // Invariant 4: The validator's voting power at a given epoch is less or equal to the total amount of tokens delegated to that validator.
+    // This is not an equality due to slashing. Next invariant checks the equality restricted to no slashing.
+    val stakeEqualOrLessSumBonds = VALIDATORS.forall(validator => USERS.fold(0, (sum, user) => 
+                                                                           sum + delegators.get(user).bonded.get(validator).fold(0, (total, elem) =>
+                                                                                                                                     total + elem.amount) ) >= validators.get(validator).stake.get(pos.epoch + PIPELINE_OFFSET))
+
+    // Invariant 5: If no slashing occurs, the validator's voting power at a given epoch is equal to the total amount of tokens delegated to that validator.
+    val noSlashingStakeEqualSumBonds = pos.slashPool == 0 implies VALIDATORS.forall(validator => USERS.fold(0, (sum, user) => 
+                                                                                                sum + delegators.get(user).bonded.get(validator).fold(0, (total, elem) => 
+                                                                                                                                                         total + elem.amount)) == validators.get(validator).stake.get(pos.epoch + PIPELINE_OFFSET))
+
+    // Invariant 6: The total amount of tokens is constant.
+    val totalAmountTokensConstant = USERS.fold(0, (sum, user) => sum + delegators.get(user).balance) + pos.posAccount + pos.slashPool== size(USERS)*INIT_BALANCE
+
+    // Invariant 7: A validator's stake cannot become negative.
     val stakeGreaterZero = VALIDATORS.forall(validator =>
                                              pos.epoch.to(pos.epoch + PIPELINE_OFFSET).forall(e => validators.get(validator).stake.get(e) >= 0))
 
-    // Invariant 4: The PoS account cannot become negative.
-    val posAccountGreaterZero = pos.posAccount >= 0
-
-    // Invariant 5: The validator's stake is the sum of its delegations.
-    val stakeEqualSumBonds = VALIDATORS.forall(validator => USERS.fold(0, (sum, user) => 
-                                                                           sum + delegators.get(user).bonded.get(validator).fold(0, (total, elem) =>
-                                                                                                                                     total + elem.amount) ) == validators.get(validator).stake.get(pos.epoch + PIPELINE_OFFSET))
-
-    //Invarriant 6: The user's balance cannot become greater than the initial balance
+    //Invariant 8: The user's balance cannot become greater than the initial balance
     val boundedBalance = USERS.forall(user => delegators.get(user).balance <= INIT_BALANCE)
 
     // All invariants
-    val allInvariants = totalAmountTokensConstant and
-                        balanceGreaterZero and
-                        stakeGreaterZero and
+    val allInvariants = balanceGreaterZero and
                         posAccountGreaterZero and
-                        //stakeEqualSumBonds and
+                        posAccountZero and
+                        stakeEqualOrLessSumBonds and
+                        noSlashingStakeEqualSumBonds and
+                        totalAmountTokensConstant and
+                        stakeGreaterZero and
                         boundedBalance
     
     /* ****************************************************************************
@@ -444,14 +457,15 @@ module namada {
     action step: bool = {
         nondet user = USERS.oneOf()
         nondet validator = VALIDATORS.oneOf()
-        nondet amount = 1.to(MAX_UINT).oneOf()
+        nondet amount = 0.to(MAX_UINT).oneOf()
         nondet e = (pos.epoch - UNBONDING_OFFSET).to(pos.epoch).oneOf()
         // Execute one of the available actions/methods
         any {
-            actionEvidence(e, validator),
             actionDelegate(user, validator, amount),
             actionUnbond(user, validator, amount),
-            actionWithdraw(user, validator)
+            actionWithdraw(user, validator),
+            actionEvidence(e, validator)
+            //allUnchanged
         }
     }
 
@@ -544,17 +558,22 @@ module namada {
     run fullExecutionTest = {
       nondet user = USERS.oneOf()
       nondet validator = VALIDATORS.oneOf()
+      nondet amount = 1.to(INIT_BALANCE - 3).oneOf()
+      nondet amountUnbonded = 1.to(amount).oneOf()
       all {
+        require(UNBONDING_OFFSET<=2 and INIT_BALANCE>=4),
         init
-        .then(actionDelegate(user, validator, 10))
-        .then(actionEvidence(3, validator))
-        .then(actionUnbond(user, validator, 5))
+        .then(actionDelegate(user, validator, amount))
+        .then(actionEvidence(UNBONDING_OFFSET + 1, validator))
+        .then(actionUnbond(user, validator, amountUnbonded))
         .then(actionDelegate(user, validator, 1))
         .then(actionDelegate(user, validator, 1))
         .then(actionDelegate(user, validator, 1))
         .then(actionWithdraw(user, validator))
         // the 5 tokens unbonded shoul be slashed
-        .then(all{ assert(delegators.get(user).balance == 7), allUnchanged})
+        .then(all{ assert(delegators.get(user).balance == INIT_BALANCE - amount - 3),
+                   assert(pos.slashPool == amount),
+                   allUnchanged })
         
       }
     }

--- a/2023/Q2/artifacts/PoS-quint/namada.qnt
+++ b/2023/Q2/artifacts/PoS-quint/namada.qnt
@@ -1,0 +1,525 @@
+// -*- mode: Bluespec; -*-
+/* ****************************************************************************
+  This encodes the proof-of-stake system of Namada.
+
+  Manuel Bravo, Informal Systems, 2023
+**************************************************************************** */
+
+module namada {
+
+  import basicSpells.* from "./basicSpells"
+  import manuSpells.* from "./manuSpells"
+
+    /* ****************************************************************************
+    * Data Types
+    * ************************************************************************* */
+
+    // Represent addresses as strings
+    type Address = str
+
+    // Represent epochs as integers
+    type Epoch = int
+
+    // Bond record to record the bond starting epoch
+    type Bond = {
+      start: Epoch,
+      amount: int
+    }
+
+    // Unbond record to record when the associated bond started and the unbonding epoch
+    type Unbond = {
+      start: Epoch,
+      end: Epoch,
+      amount: int
+    }
+
+    // Slash record
+    type Slash = {
+      id: int,
+      epoch: epoch,
+      validator: Address,
+      rate: int
+    }
+
+    // Delegator state
+    type DelegatorState = {
+      balance: int,
+      bonded: Address -> Set[Bond],
+      unbonded: Address -> Set[Unbond]
+    }
+
+    // Validator state
+    type ValidatorState = {
+      address: Address,
+      stake: Epoch -> int,
+      slashes: List[Slash],
+      frozen: Epoch,
+      totalUnbonded: Epoch -> Epoch -> int
+    }
+
+    // Proof-of-stake system state
+    type PosState = {
+      posAccount: int,
+      slashPool: int,
+      epoch: Epoch,
+      counterTxs: int,
+      enqueuedSlashes: Epoch -> Set[Slash],
+      counterSlashes: int
+    }
+
+    // Result record returned by any of the three PoS functions: delegate, unbond and withdraw
+    type ResultTx = {
+      success: bool,
+      delegatorState: DelegatorState,
+      validatorState: ValidatorState,
+      posState: PosState
+    }
+
+    /* ****************************************************************************
+    * Specification Parameters
+    * ************************************************************************* */
+
+    // Max uint
+    pure val MAX_UINT = 10
+
+    // Users initial balances
+    pure val INIT_BALANCE = 20
+
+    // set of all user addresses
+    pure val USERS = Set("alice", "bob")
+
+    // set of all validator addresses
+    pure val VALIDATORS = Set("alice")
+
+    // transactions per epoch
+    pure val TXS_EPOCH = 1
+
+    // unbonding offset
+    pure val UNBONDING_OFFSET = 2
+
+    // pipeline offset
+    pure val PIPELINE_OFFSET = 1
+
+    // cubic offset
+    pure val CUBIC_OFFSET = 1
+
+    /* ****************************************************************************
+    * State machine state
+    * ************************************************************************* */
+
+    // Delegator state
+    var delegators: Address -> DelegatorState
+    // Validator state
+    var validators: Address -> ValidatorState
+    // Proof-of-stake state
+    var pos: PosState
+
+    /* ****************************************************************************
+    * Execution state
+    * ************************************************************************* */
+
+    // Used to limit the misbehaving of a validator: at most once within any window of unbonding offset epochs
+    pure val limitEvidence = false
+
+    // Used to guarantee every step produces a state transition
+    // IMPORTANT: Set to false for tests
+    pure val enforceStateTransition = true
+
+    // Last transaction executed by step.
+    // Amount is only relevant for delegate and unbond; it is alwasy 0 for withdraw.
+    var lastTx: {tag: str, result: bool, user: Address, validator: Address, amount: int}
+
+    /**************************************************************************
+    * Helper functions
+    * ************************************************************************* */
+
+    pure def min(x, y) = if (x < y) x else y
+
+    /*
+    * The function addRecord adds an a record to a set of them.
+    */
+    pure def addRecord(setRecords, record) = setRecords.union(Set(record))
+
+    pure def unbondBond(acc: {remainder: int, toRemove: Set[Bond], new: Bond}, bond: Bond): {remainder: int, toRemove: Set[Bond], new: Bond} = 
+      val amountUnbonded = min(bond.amount, acc.remainder)
+      {remainder: acc.remainder - amountUnbonded,
+       toRemove: addRecord(acc.toRemove, bond),
+       new: if (bond.amount > acc.remainder) {start: bond.start, amount: bond.amount - acc.remainder} else acc.new}
+
+    pure def iterateBondsUpToAmount(bonds: Set[Bond], amount: int): {toRemove: Set[Bond], new: Bond} = {
+      val result = bonds.fold({remainder: amount, toRemove: Set(), new: {start: -1, amount: 0}},
+                              (acc, bond) => if (acc.remainder == 0) acc else unbondBond(acc, bond))
+      {toRemove: result.toRemove, new: result.new}
+    }
+
+    pure def computeSlashableAmount(slash: Slash, initAmount: int, computedSlashes: Epoch -> int): int = {
+      val updatedAmount = computedSlashes.keys().filter(x => x + UNBONDING_OFFSET < slash.epoch)
+                                                .fold(initAmount, (acc, e) => acc - computedSlashes.get(e))
+      updatedAmount*slash.rate
+    }
+
+    pure def applyListSlashes(listSlashes: List[Slash], amount: int): int = {
+
+      listSlashes.foldl({finalAmount: amount, computedSlashes: Map()}, (acc, slash) => val slashAmount = computeSlashableAmount(slash, amount, acc.computedSlashes)
+                                                                                       {finalAmount: acc.finalAmount - slashAmount,
+                                                                                        computedSlashes: acc.map.set(slash.epoch, slashAmount)}).finalAmount
+    }
+
+    /**************************************************************************
+    * Main functions
+    * ************************************************************************* */
+
+
+    /*
+    * The function delegate is called when a user wants to delegate tokens to a validator.
+    * 1. First it checks that the user has enough tokens in its account.
+    * 2. Then it locks those tokens by transferring then from the user's account to the PoS special account.
+    * 3. It records that the user has delegated amount tokens to the validator.
+    * 4. It increases the validator's stake.
+    */
+    pure def delegate(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState, amount: int): ResultTx = {
+      if (amount <= delegatorState.balance) {
+        val updatedDelegatorState = delegatorState.with("balance", delegatorState.balance - amount)
+                                                  .with("bonded", delegatorState.bonded.set(validatorState.address,
+                                                                                            addRecord(delegatorState.bonded.get(validatorState.address),
+                                                                                                      {start: posState.epoch + PIPELINE_OFFSET, amount: amount})))
+        val updatedValidatorState = validatorState.with("stake", validatorState.stake.set(posState.epoch + PIPELINE_OFFSET,
+                                                                                          validatorState.stake.get(posState.epoch + PIPELINE_OFFSET) + amount))
+        val updatedPosState = posState.with("posAccount", posState.posAccount + amount)
+        {success: true, delegatorState: updatedDelegatorState, validatorState: updatedValidatorState, posState: updatedPosState}
+      } else {
+        {success: false, delegatorState: delegatorState, validatorState: validatorState, posState: posState}
+      }
+    }
+
+    /*
+    * The function unbond is called when a user wants to unbond tokens from a validator.
+    * 1. First it checks that the user has enough tokens bonded to the validator.
+    * 2. Then it records that amount of tokens is unbonded by subtracting amount from bonded and adding to unbonded.
+    * 3. Finally, it decreases the validator's stake.
+    */
+    pure def unbond(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState, amount: int): ResultTx = {
+      val totalBonded = delegatorState.bonded.get(validatorState.address).fold(0, (sum, elem) => sum + elem.amount)      
+      if (amount < totalBonded and validatorState.frozen < posState.epoch) {
+        val endEpoch = posState.epoch + PIPELINE_OFFSET + UNBONDING_OFFSET
+        val resultUnbonding = iterateBondsUpToAmount(delegatorState.bonded.get(validatorState.address), amount)
+        val newUnbonds = resultUnbonding.toRemove.map(bond => if (bond.start == resultUnbonding.new.start) {start: bond.start, end: endEpoch, amount: bond.amount -  resultUnbonding.new.amount}
+                                                              else {start: bond.start, end: endEpoch, amount: bond.amount})
+        val updatedBonded = delegatorState.bonded.set(validatorState.address,
+                                                      if (resultUnbonding.new.start == -1) delegatorState.bonded.get(validatorState.address).exclude(resultUnbonding.toRemove)
+                                                      else delegatorState.bonded.get(validatorState.address).exclude(resultUnbonding.toRemove).union(Set(resultUnbonding.new)))                                                         
+        val updatedDelegatorState = delegatorState.with("bonded", updatedBonded)
+                                                  .with("unbonded", delegatorState.unbonded.set(validatorState.address, delegatorState.unbonded.get(validatorState.address).union(newUnbonds)))                                  
+        val amountAfterSlashing = newUnbonds.fold(0, (sum, element) => val listSlashes = validatorState.slashes.select(slash => element.start <= slash.epoch)
+                                                                       sum + applyListSlashes(listSlashes, element.amount))
+        val updatedTotalUnbonded = newUnbonds.fold(validatorState.totalUnbonded.get(posState.epoch),
+                                                   (acc, element) => acc.safeSet(element.start, acc.getOrElse(element.start, 0) + element.amount))
+        val updatedValidatorState = validatorState.with("stake", validatorState.stake.set(posState.epoch + PIPELINE_OFFSET,
+                                                                                          validatorState.stake.get(posState.epoch + PIPELINE_OFFSET) - amountAfterSlashing))
+                                                  .with("totalUnbonded", validatorState.totalUnbonded.set(posState.epoch + PIPELINE_OFFSET, updatedTotalUnbonded))
+        {success: true, delegatorState: updatedDelegatorState, validatorState: updatedValidatorState, posState: posState}
+      } else {
+        {success: false, delegatorState: delegatorState, validatorState: validatorState, posState: posState}
+      }
+    }
+
+    /*
+    * The function withdraw is called when a user wants to withdraw tokens from a validator.
+    * 1. First it computes the amount of tokens that can be withdrawn and returns an error in case there are none.
+    * 2. Then records that those tokens are withdrawn by removing the withdrawable unbond records from unbonded.
+    * 3. Finally, it unlocks the tokens by transferring them from the PoS special account to the user's account.
+    */
+    pure def withdraw(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState): ResultTx = {
+      // Filter the the set of unbonds that can be withdrawn
+      val setWithdrawn = delegatorState.unbonded.get(validatorState.address).filter(element => element.end <= posState.epoch)
+      // Compute the total amount of withdrawable tokens
+      val amount = setWithdrawn.fold(0, (sum, element) => sum + element.amount)
+      if (amount > 0) {
+        // Compute how much out of amount is withdrawn after slashing by leveraging applyListSlashes
+        val amountAfterSlashing = setWithdrawn.fold(0, (sum, element) => val listSlashes = validatorState.slashes.select(slash => element.start <= slash.epoch and
+                                                                                                                                  element.end > slash.epoch)
+                                                                         sum + applyListSlashes(listSlashes, element.amount))
+        // Remove the sent of withdrawn unbonds from the set of unbonds
+        val updatedUnbonded = delegatorState.unbonded.get(validatorState.address).exclude(setWithdrawn)
+        // Transfer withdrawn tokens from the PoS account to the user's account
+        val updatedDelegatorState = delegatorState.with("unbonded", delegatorState.unbonded.set(validatorState.address, updatedUnbonded))
+                                                  .with("balance", delegatorState.balance + amountAfterSlashing)
+        val updatedPosState = posState.with("posAccount", posState.posAccount - amountAfterSlashing)
+        {success: true, delegatorState: updatedDelegatorState, validatorState: validatorState, posState: updatedPosState}
+      } else {
+        {success: false, delegatorState: delegatorState, validatorState: validatorState, posState: posState}
+      }
+    }
+
+    pure def computeTotalUnbonded(slash: Slash, prevSlashes: List[Slash], totalUnbonded: Epoch -> int): int = {
+      val epochs = totalUnbonded.keys().filter(e => e <= slash.epoch and totalUnbonded.get(e) > 0)
+      epochs.fold(0, (sum, e) => sum + applyListSlashes(prevSlashes.select(s => e <= s.epoch and s.epoch + UNBONDING_OFFSET < slash.epoch), totalUnbonded.get(e)))
+    }
+
+    pure def slashValidator(initMap: Epoch -> int, curEpoch: Epoch, stake: int, slash: Slash, prevSlashes: List[Slash], totalUnbonded: Epoch -> Epoch -> int, finalRate: int): Epoch -> int = {
+      val initTotalUnbonded = slash.epoch.to(curEpoch).fold(0, (sum, e) => sum + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e)))
+      val result = (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).fold((initTotalUnbonded, initMap), (acc, e) => val updatedTotalUnbonded = acc._1 + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e))
+                                                                                                            val slashedAmount = (stake - updatedTotalUnbonded) * finalRate
+                                                                                                            (updatedTotalUnbonded, acc._2.set(e, acc._2.get(e) + slashedAmount)))
+      result._2
+    }
+
+    pure def computeFinalRate(setSlashes: Set[Slash]): int = {
+      1
+    } 
+
+    pure def endOfEpoch(validatorsState: Address -> ValidatorState, posState: PosState, curEpoch: Epoch): {validatorsState: Address -> ValidatorState, posState: PosState} = {
+      val finalRate = computeFinalRate(posState.enqueuedSlashes.get(curEpoch-1).union(posState.enqueuedSlashes.get(curEpoch))
+                                                                               .union(posState.enqueuedSlashes.get(curEpoch+1)))
+      val initMap = VALIDATORS.mapBy(v => (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).mapBy(e => 0))
+      val mapValidatorSlash = posState.enqueuedSlashes.get(curEpoch).fold(initMap, (acc, slash) => acc.set(slash.validator, slashValidator(acc.get(slash.validator),
+                                                                                                                                           curEpoch,
+                                                                                                                                           validatorsState.get(slash.validator).stake.get(slash.epoch),
+                                                                                                                                           slash,
+                                                                                                                                           validatorsState.get(slash.validator).slashes,
+                                                                                                                                           validatorsState.get(slash.validator).totalUnbonded,
+                                                                                                                                           finalRate)))
+      val updatedValidators = VALIDATORS.mapBy(v => validatorsState.get(v).with("stake",(curEpoch-UNBONDING_OFFSET+1).to(curEpoch+1+PIPELINE_OFFSET).mapBy(e => if (e < curEpoch+1+PIPELINE_OFFSET) validatorsState.get(v).stake.get(e) -
+                                                                                                                                                                  if (e >= curEpoch+1) mapValidatorSlash.get(v).get(e) else 0
+                                                                                                                                                                else validatorsState.get(v).stake.get(e-1) - mapValidatorSlash.get(v).get(e-1))) 
+                                                                         .with("totalUnbonded", (curEpoch+1).to(curEpoch+1+PIPELINE_OFFSET).mapBy(e => if (e < curEpoch+1+PIPELINE_OFFSET) validatorsState.get(v).totalUnbonded.get(e)
+                                                                                                                                                       else Map()))
+                                                                         .with("slashes", posState.enqueuedSlashes.get(curEpoch).filter(s => s.validator == v).fold(validatorsState.get(v).slashes, (acc, s) => acc.append(s.with("rate", finalRate)))))                                                                            
+      val updatedPos =  posState.with("epoch", curEpoch + 1)
+                                .with("counterTxs", 0)
+                                .with("slashPool", posState.enqueuedSlashes.get(curEpoch).fold(0, (sum, s) => sum + validatorsState.get(s.validator).stake.get(s.epoch)*finalRate))
+                                .with("enqueuedSlashes", (curEpoch).to(curEpoch+1+UNBONDING_OFFSET).mapBy(e => if (e < curEpoch+1+UNBONDING_OFFSET) posState.enqueuedSlashes.get(e)
+                                                                                                                 else Set()))                                                                      
+      {validatorsState: updatedValidators, posState: updatedPos}                                                                                                                             
+    }
+
+    pure def proccessEvidence(e: Epoch, validatorState: ValidatorState, posState: PosState): {validatorState: ValidatorState, posState: PosState} = {
+      val nextSlashCounter = posState.counterSlashes + 1
+      val slash = {id: posState.counterSlashes + 1, epoch: e, validator: validatorState.address, rate: 1}
+      {validatorState: validatorState.with("frozen", max(validatorState.frozen, e + UNBONDING_OFFSET)),
+       posState: posState.with("counterSlashes", posState.counterSlashes + 1)
+                         .with("enqueuedSlashes", posState.enqueuedSlashes.set(e + UNBONDING_OFFSET, posState.enqueuedSlashes.get(e + UNBONDING_OFFSET).union(Set(slash))))}
+    }
+
+
+    /* ****************************************************************************
+    * Actions
+    * ************************************************************************* */
+
+    /*
+    * The action commonTxAfter is called after a transaction is executed.
+    * 1. It first checks if it is the last transaction of the current epoch.
+    * 2. If it is the last transaction of the epoch, it calls the endOfEpoch.
+    * 3. Otherwise, it updates the variables using the result of the transaciton.
+    */
+
+    action commonTxAfter(user: Address, validator: Address, result: ResultTx): bool = all {
+      if (pos.counterTxs + 1 == TXS_EPOCH) {
+        val resultEndOfEpoch = endOfEpoch(validators.set(validator, result.validatorState), result.posState, pos.epoch)
+        all {
+          delegators' = delegators.set(user, result.delegatorState),
+          validators' = resultEndOfEpoch.validatorsState,
+          pos' = resultEndOfEpoch.posState,
+        }
+      } else {
+        all {
+          delegators' = delegators.set(user, result.delegatorState),
+          validators' = validators.set(validator, result.validatorState),
+          pos' = result.posState.with("counterTxs", result.posState.counterTxs + 1)
+        }
+      }
+    }
+
+    action actionDelegate(user: Address, validator: Address, amount: int): bool = all {
+      val result = delegate(delegators.get(user), validators.get(validator), pos, amount)
+      all {
+        if (enforceStateTransition) require(result.success) else true,
+        commonTxAfter(user, validator, result),
+        lastTx' = {tag: "Delegate", result: result.success, user: user, validator: validator, amount: amount}
+      }
+    }
+
+    action actionUnbond(user: Address, validator: Address, amount: int): bool = all {
+      val result = unbond(delegators.get(user), validators.get(validator), pos, amount)
+      all {
+        if (enforceStateTransition) require(result.success) else true,
+        commonTxAfter(user, validator, result),
+        lastTx' = {tag: "Unbond", result: result.success, user: user, validator: validator, amount: amount}
+      }
+    }
+
+    action actionWithdraw(user: Address, validator: Address): bool = all {
+      val result = withdraw(delegators.get(user), validators.get(validator), pos)
+      all {
+        if (enforceStateTransition) require(result.success) else true,
+        commonTxAfter(user, validator, result),
+        lastTx' = {tag: "Withdraw", result: result.success, user: user, validator: validator, amount: 0}
+      }
+    }
+
+    action actionEvidence(e: Epoch, validator: Address): bool = all {
+      if (limitEvidence) require(validators.get(validator).frozen < e) else true,
+      val result = proccessEvidence(e, validators.get(validator), pos)
+      all {
+        validators' = validators.set(validator, result.validatorState),
+        pos' = result.posState,
+        delegators' = delegators,
+        lastTx' = {tag: "Evidence", result: true, user: "", validator: validator, amount: e}
+      }
+    }
+
+    /* ****************************************************************************
+    * Invariants
+    * ************************************************************************* */
+
+    // Invariant 1: The total amount of tokens is constant.
+    val totalAmountTokensConstant = USERS.fold(0, (sum, user) => sum + delegators.get(user).balance) + pos.posAccount + pos.slashPool== size(USERS)*INIT_BALANCE
+
+    // Invariant 2: A delegator's balance cannot become negative.
+    val balanceGreaterZero = USERS.forall(user => delegators.get(user).balance >= 0)
+
+    // Invariant 3: A validator's stake cannot become negative.
+    val stakeGreaterZero = VALIDATORS.forall(validator =>
+                                             pos.epoch.to(pos.epoch + PIPELINE_OFFSET).forall(e => validators.get(validator).stake.get(e) >= 0))
+
+    // Invariant 4: The PoS account cannot become negative.
+    val posAccountGreaterZero = pos.posAccount >= 0
+
+    // Invariant 5: The validator's stake is the sum of its delegations.
+    val stakeEqualSumBonds = VALIDATORS.forall(validator => USERS.fold(0, (sum, user) => 
+                                                                           sum + delegators.get(user).bonded.get(validator).fold(0, (total, elem) =>
+                                                                                                                                     total + elem.amount) ) == validators.get(validator).stake.get(pos.epoch + PIPELINE_OFFSET))
+
+    //Invarriant 6: The user's balance cannot become greater than the initial balance
+    val boundedBalance = USERS.forall(user => delegators.get(user).balance <= INIT_BALANCE)
+
+    // All invariants
+    val allInvariants = totalAmountTokensConstant and
+                        balanceGreaterZero and
+                        stakeGreaterZero and
+                        posAccountGreaterZero and
+                        //stakeEqualSumBonds and
+                        boundedBalance
+    
+    /* ****************************************************************************
+    * Execution
+    * ************************************************************************* */
+
+    action allUnchanged: bool = all {
+      delegators' = delegators,
+      validators' = validators,
+      pos' = pos,
+      lastTx' = lastTx
+    }
+
+    // State initialization: assumes that users start with some initial balance.
+    action init: bool = all {
+      val initEpoch = UNBONDING_OFFSET
+      all {
+        delegators' = USERS.mapBy(user => {balance: INIT_BALANCE,
+                                          bonded: VALIDATORS.mapBy(x => Set()),
+                                          unbonded: VALIDATORS.mapBy(x => Set())}),
+        validators' = VALIDATORS.mapBy(validator => {address: validator,
+                                                     stake: 0.to(initEpoch+PIPELINE_OFFSET).mapBy(e => 0),
+                                                     totalUnbonded: initEpoch.to(initEpoch+PIPELINE_OFFSET).mapBy(e => Map()),
+                                                     slashes: List(),
+                                                     frozen: 0}),
+        pos' = {posAccount: 0,
+                slashPool: 0,
+                epoch: initEpoch,
+                counterTxs: 0,
+                enqueuedSlashes: (initEpoch-1).to(initEpoch+UNBONDING_OFFSET).mapBy(e => Set()),
+                counterSlashes: 0},
+        lastTx' = { tag: "Init", result: true, user: "", validator: "", amount: 0}
+      }
+    }
+
+    /*
+    * Execution of the state machine.
+    * 1. Pick a random amount from 0 to MAX_UINT, a user and a validator
+    * 2. Execute one of the actions: delegate, unbond or withdraw.
+    */
+    action step: bool = {
+        nondet user = USERS.oneOf()
+        nondet validator = VALIDATORS.oneOf()
+        nondet amount = 1.to(MAX_UINT).oneOf()
+        nondet e = (pos.epoch - UNBONDING_OFFSET).to(pos.epoch).oneOf()
+        // Execute one of the available actions/methods
+        any {
+            actionEvidence(e, validator),
+            actionDelegate(user, validator, amount),
+            actionUnbond(user, validator, amount),
+            actionWithdraw(user, validator)
+        }
+    }
+
+    /*
+    * The test testDelegate is a unitest-like test for the delegate function.
+    */
+    run delegateTest = {
+      val delegatorState = {balance: INIT_BALANCE, bonded: USERS.mapBy(x => Set()), unbonded: USERS.mapBy(x => Set())}
+      val validatorState = {address: "alice",
+                            stake: 0.to(UNBONDING_OFFSET).mapBy(e => 0),
+                            totalUnbonded: 1.to(1+PIPELINE_OFFSET).mapBy(e => Map()),
+                            slashes: List(),
+                            frozen: 0}
+      val posState = {posAccount: 0,
+                      slashPool: 0,
+                      epoch: 1,
+                      counterTxs: 0,
+                      enqueuedSlashes: 0.to(UNBONDING_OFFSET).mapBy(e => Set()),
+                      counterSlashes: 0}
+      nondet amount = 0.to(MAX_UINT).oneOf()
+      val result = delegate(delegatorState, validatorState, posState, amount)
+      if (result.success) {
+        all {
+          assert(result.delegatorState.balance == INIT_BALANCE - amount),
+          assert(result.delegatorState.bonded.get(validatorState.address).contains({start: 1 + PIPELINE_OFFSET, amount: amount})),
+          assert(result.delegatorState.unbonded.get(validatorState.address) == Set()),
+          assert(result.validatorState.stake.get(1 + PIPELINE_OFFSET) == amount),
+          assert(result.posState.posAccount == amount)
+        }
+      } else {
+        all {
+          assert(amount > INIT_BALANCE),
+          assert(result.delegatorState == delegatorState),
+          assert(result.validatorState == validatorState),
+          assert(result.posState == posState)
+        }
+      }
+    }
+
+    /*
+    * The test testUnbondingPeriod checks that the unbonding period is enforced.
+    */
+    run successfulWithdrawTest = {
+      nondet user = USERS.oneOf()
+      nondet validator = VALIDATORS.oneOf()
+      all {
+        init
+        .then(actionDelegate(user, validator, 10))
+        .then(actionUnbond(user, validator, 5))
+        .then(actionDelegate(user, validator, 1))
+        .then(actionDelegate(user, validator, 1))
+        .then(actionDelegate(user, validator, 1))
+        .then(actionWithdraw(user, validator))
+        .then(all{ assert(delegators.get(user).balance == 12), allUnchanged})
+        
+      }
+    }
+
+    /*
+    * The test testUnbondingPeriod checks that the unbonding period is enforced.
+    */
+    run unbondingPeriodTest = {
+      nondet user = USERS.oneOf()
+      nondet validator = VALIDATORS.oneOf()
+      all {
+        init
+        .then(actionDelegate(user, validator, 8))
+        .then(actionUnbond(user, validator, 5))
+        .then(actionWithdraw(user, validator))
+        .then(all{ assert(delegators.get(user).balance == 12), allUnchanged})
+      }
+    }
+}

--- a/2023/Q2/artifacts/PoS-quint/namada.qnt
+++ b/2023/Q2/artifacts/PoS-quint/namada.qnt
@@ -22,20 +22,24 @@ module namada {
 
     // Bond record to record the bond starting epoch
     type Bond = {
+      // Epoch at which the bond start contributing to the validator's stake
       start: Epoch,
+      // Amount of bonded tokens
       amount: int
     }
 
     // Unbond record to record when the associated bond started and the unbonding epoch
     type Unbond = {
+      // Epoch at which the unbond tokens started contributing to the validator's stake
       start: Epoch,
+      // Epoch at which the unbonded toeksn can be withdrawn
       end: Epoch,
+      // Amount of unbonded tokens
       amount: int
     }
 
     // Slash record
     type Slash = {
-      id: int,
       epoch: epoch,
       validator: Address,
       rate: int
@@ -43,28 +47,42 @@ module namada {
 
     // Delegator state
     type DelegatorState = {
+      // User's current balance
       balance: int,
+      // User's bonds: a map from validator to set of bonds
       bonded: Address -> Set[Bond],
+      // User's unbonds: a map from validator to set of unbonds
       unbonded: Address -> Set[Unbond]
     }
 
     // Validator state
     type ValidatorState = {
+      // Validator's address
       address: Address,
+      // Epoched stake: a map from epoch to stake
       stake: Epoch -> int,
+      // Ordered by epoch list of already processed slashes
       slashes: List[Slash],
+      // Keeps tracks of the epoch until which a validator is frozen
       frozen: Epoch,
+      // Each validator keeps track of unbonded tokens per epoch
+      // totalUnbonded is a map from unbonding epoch to unbonded bonds
+      // The unbonded bonds are tracked in a map from bond starting epoch to amount of tokens
       totalUnbonded: Epoch -> Epoch -> int
     }
 
     // Proof-of-stake system state
     type PosState = {
+      // A special PoS account that receives staked tokens
       posAccount: int,
+      // The slash pool receives slashed tokens
       slashPool: int,
+      // Current epoch
       epoch: Epoch,
+      // Number of transactions executed in the current epoch
       counterTxs: int,
+      // A map from epoch to the set of slashes scheduled to be processed
       enqueuedSlashes: Epoch -> Set[Slash],
-      counterSlashes: int
     }
 
     // Result record returned by any of the three PoS functions: delegate, unbond and withdraw
@@ -92,6 +110,8 @@ module namada {
     pure val VALIDATORS = Set("alice")
 
     // transactions per epoch
+    // the spec is not fully ready to handle multiple txs per epoch
+    // we would need to handle duplicate bonds and unbonds
     pure val TXS_EPOCH = 1
 
     // unbonding offset
@@ -123,27 +143,23 @@ module namada {
 
     // Used to guarantee every step produces a state transition
     // IMPORTANT: Set to false for tests
-    pure val enforceStateTransition = true
+    pure val enforceStateTransition = false
 
     // Last transaction executed by step.
-    // Amount is only relevant for delegate and unbond; it is alwasy 0 for withdraw.
+    // Amount is over used by the actions:
+    // It respresents the amount delegated or unbonded for delegate and unbond respectively; 
+    // It is always 0 for withdraw and advanceEpoch;
+    // It is the misbehaving epoch in Processevidence;
     var lastTx: {tag: str, result: bool, user: Address, validator: Address, amount: int}
 
     /**************************************************************************
     * Helper functions
     * ************************************************************************* */
 
-    pure def min(x, y) = if (x < y) x else y
-
-    /*
-    * The function addRecord adds an a record to a set of them.
-    */
-    pure def addRecord(setRecords, record) = setRecords.union(Set(record))
-
     pure def unbondBond(acc: {remainder: int, toRemove: Set[Bond], new: Bond}, bond: Bond): {remainder: int, toRemove: Set[Bond], new: Bond} = 
       val amountUnbonded = min(bond.amount, acc.remainder)
       {remainder: acc.remainder - amountUnbonded,
-       toRemove: addRecord(acc.toRemove, bond),
+       toRemove: acc.toRemove.setAdd(bond),
        new: if (bond.amount > acc.remainder) {start: bond.start, amount: bond.amount - acc.remainder} else acc.new}
 
     pure def iterateBondsUpToAmount(bonds: Set[Bond], amount: int): {toRemove: Set[Bond], new: Bond} = {
@@ -181,8 +197,7 @@ module namada {
       if (amount <= delegatorState.balance and amount > 0) {
         val updatedDelegatorState = delegatorState.with("balance", delegatorState.balance - amount)
                                                   .with("bonded", delegatorState.bonded.set(validatorState.address,
-                                                                                            addRecord(delegatorState.bonded.get(validatorState.address),
-                                                                                                      {start: posState.epoch + PIPELINE_OFFSET, amount: amount})))
+                                                                                            delegatorState.bonded.get(validatorState.address).setAdd({start: posState.epoch + PIPELINE_OFFSET, amount: amount})))                                                                       
         val updatedValidatorState = validatorState.with("stake", validatorState.stake.set(posState.epoch + PIPELINE_OFFSET,
                                                                                           validatorState.stake.get(posState.epoch + PIPELINE_OFFSET) + amount))
         val updatedPosState = posState.with("posAccount", posState.posAccount + amount)
@@ -296,11 +311,9 @@ module namada {
     }
 
     pure def proccessEvidence(e: Epoch, validatorState: ValidatorState, posState: PosState): {validatorState: ValidatorState, posState: PosState} = {
-      val nextSlashCounter = posState.counterSlashes + 1
-      val slash = {id: nextSlashCounter, epoch: e, validator: validatorState.address, rate: 1}
+      val slash = {epoch: e, validator: validatorState.address, rate: 1}
       {validatorState: validatorState.with("frozen", max(validatorState.frozen, e + UNBONDING_OFFSET)),
-       posState: posState.with("counterSlashes", nextSlashCounter)
-                         .with("enqueuedSlashes", posState.enqueuedSlashes.set(e + UNBONDING_OFFSET, posState.enqueuedSlashes.get(e + UNBONDING_OFFSET).union(Set(slash))))}
+       posState: posState.with("enqueuedSlashes", posState.enqueuedSlashes.set(e + UNBONDING_OFFSET, posState.enqueuedSlashes.get(e + UNBONDING_OFFSET).union(Set(slash))))}
     }
 
 
@@ -454,8 +467,7 @@ module namada {
                 slashPool: 0,
                 epoch: initEpoch,
                 counterTxs: 0,
-                enqueuedSlashes: (initEpoch-1).to(initEpoch+UNBONDING_OFFSET).mapBy(e => Set()),
-                counterSlashes: 0},
+                enqueuedSlashes: (initEpoch-1).to(initEpoch+UNBONDING_OFFSET).mapBy(e => Set())},
         lastTx' = { tag: "Init", result: true, user: "", validator: "", amount: 0}
       }
     }
@@ -483,11 +495,11 @@ module namada {
 
     run applyListSlashesTest = {
       val initEpoch = 2
-      val list1 = [{id: 1, epoch: initEpoch, validator: "alice", rate: 1}]
-      val list2 = [{id: 1, epoch: initEpoch, validator: "alice", rate: 1},
-                   {id: 2, epoch: initEpoch+UNBONDING_OFFSET+1, validator: "alice", rate: 1} ]
-      val list3 = [{id: 1, epoch: initEpoch, validator: "alice", rate: 1},
-                   {id: 2, epoch: initEpoch, validator: "alice", rate: 1} ]
+      val list1 = [{epoch: initEpoch, validator: "alice", rate: 1}]
+      val list2 = [{epoch: initEpoch, validator: "alice", rate: 1},
+                   {epoch: initEpoch+UNBONDING_OFFSET+1, validator: "alice", rate: 1} ]
+      val list3 = [{epoch: initEpoch, validator: "alice", rate: 1},
+                   {epoch: initEpoch, validator: "alice", rate: 1} ]
       all {
         assert(applyListSlashes([], 100) == 100),
         assert(applyListSlashes(list1, 100) == 0),
@@ -511,8 +523,7 @@ module namada {
                       slashPool: 0,
                       epoch: 1,
                       counterTxs: 0,
-                      enqueuedSlashes: 0.to(UNBONDING_OFFSET).mapBy(e => Set()),
-                      counterSlashes: 0}
+                      enqueuedSlashes: 0.to(UNBONDING_OFFSET).mapBy(e => Set())}
       nondet amount = 0.to(MAX_UINT).oneOf()
       val result = delegate(delegatorState, validatorState, posState, amount)
       if (result.success) {
@@ -525,7 +536,7 @@ module namada {
         }
       } else {
         all {
-          assert(amount > INIT_BALANCE),
+          assert(amount > INIT_BALANCE or amount == 0),
           assert(result.delegatorState == delegatorState),
           assert(result.validatorState == validatorState),
           assert(result.posState == posState)

--- a/2023/Q2/artifacts/PoS-quint/namada.qnt
+++ b/2023/Q2/artifacts/PoS-quint/namada.qnt
@@ -119,7 +119,7 @@ module namada {
     * ************************************************************************* */
 
     // Used to limit the misbehaving of a validator: at most once within any window of unbonding offset epochs
-    pure val limitEvidence = false
+    pure val limitEvidence = true
 
     // Used to guarantee every step produces a state transition
     // IMPORTANT: Set to false for tests
@@ -162,7 +162,7 @@ module namada {
 
       listSlashes.foldl({finalAmount: amount, computedSlashes: Map()}, (acc, slash) => val slashAmount = computeSlashableAmount(slash, amount, acc.computedSlashes)
                                                                                        {finalAmount: acc.finalAmount - slashAmount,
-                                                                                        computedSlashes: acc.map.set(slash.epoch, slashAmount)}).finalAmount
+                                                                                        computedSlashes: acc.computedSlashes.safeSet(slash.epoch, slashAmount)}).finalAmount
     }
 
     /**************************************************************************
@@ -281,15 +281,17 @@ module namada {
                                                                                                                                            finalRate)))
       val updatedValidators = VALIDATORS.mapBy(v => validatorsState.get(v).with("stake",(curEpoch-UNBONDING_OFFSET+1).to(curEpoch+1+PIPELINE_OFFSET).mapBy(e => if (e < curEpoch+1+PIPELINE_OFFSET) validatorsState.get(v).stake.get(e) -
                                                                                                                                                                   if (e >= curEpoch+1) mapValidatorSlash.get(v).get(e) else 0
-                                                                                                                                                                else validatorsState.get(v).stake.get(e-1) - mapValidatorSlash.get(v).get(e-1))) 
-                                                                         .with("totalUnbonded", (curEpoch+1).to(curEpoch+1+PIPELINE_OFFSET).mapBy(e => if (e < curEpoch+1+PIPELINE_OFFSET) validatorsState.get(v).totalUnbonded.get(e)
+                                                                                                                                                                else validatorsState.get(v).stake.get(e-1)- mapValidatorSlash.get(v).get(e-1))) 
+                                                                         .with("totalUnbonded", (curEpoch-UNBONDING_OFFSET+1).to(curEpoch+1+PIPELINE_OFFSET).mapBy(e => if (e < curEpoch+1+PIPELINE_OFFSET) validatorsState.get(v).totalUnbonded.get(e)
                                                                                                                                                        else Map()))
-                                                                         .with("slashes", posState.enqueuedSlashes.get(curEpoch).filter(s => s.validator == v).fold(validatorsState.get(v).slashes, (acc, s) => acc.append(s.with("rate", finalRate)))))                                                                            
+                                                                         .with("slashes", posState.enqueuedSlashes.get(curEpoch).filter(s => s.validator == v).fold(validatorsState.get(v).slashes, (acc, s) => acc.append(s.with("rate", finalRate)))))
+      val totalAmountSlashed = posState.enqueuedSlashes.get(curEpoch).fold(0, (sum, s) => sum + validatorsState.get(s.validator).stake.get(s.epoch)*finalRate)                                                                     
       val updatedPos =  posState.with("epoch", curEpoch + 1)
                                 .with("counterTxs", 0)
-                                .with("slashPool", posState.enqueuedSlashes.get(curEpoch).fold(0, (sum, s) => sum + validatorsState.get(s.validator).stake.get(s.epoch)*finalRate))
+                                .with("posAccount", posState.posAccount - totalAmountSlashed)
+                                .with("slashPool", posState.slashPool + totalAmountSlashed)
                                 .with("enqueuedSlashes", (curEpoch).to(curEpoch+1+UNBONDING_OFFSET).mapBy(e => if (e < curEpoch+1+UNBONDING_OFFSET) posState.enqueuedSlashes.get(e)
-                                                                                                                 else Set()))                                                                      
+                                                                                                               else Set()))                                                                      
       {validatorsState: updatedValidators, posState: updatedPos}                                                                                                                             
     }
 
@@ -421,7 +423,7 @@ module namada {
                                           unbonded: VALIDATORS.mapBy(x => Set())}),
         validators' = VALIDATORS.mapBy(validator => {address: validator,
                                                      stake: 0.to(initEpoch+PIPELINE_OFFSET).mapBy(e => 0),
-                                                     totalUnbonded: initEpoch.to(initEpoch+PIPELINE_OFFSET).mapBy(e => Map()),
+                                                     totalUnbonded: 0.to(initEpoch+PIPELINE_OFFSET).mapBy(e => Map()),
                                                      slashes: List(),
                                                      frozen: 0}),
         pos' = {posAccount: 0,
@@ -452,6 +454,22 @@ module namada {
             actionWithdraw(user, validator)
         }
     }
+
+    run applyListSlashesTest = {
+      val initEpoch = 2
+      val list1 = [{id: 1, epoch: initEpoch, validator: "alice", rate: 1}]
+      val list2 = [{id: 1, epoch: initEpoch, validator: "alice", rate: 1},
+                   {id: 2, epoch: initEpoch+UNBONDING_OFFSET+1, validator: "alice", rate: 1} ]
+      val list3 = [{id: 1, epoch: initEpoch, validator: "alice", rate: 1},
+                   {id: 2, epoch: initEpoch, validator: "alice", rate: 1} ]
+      all {
+        assert(applyListSlashes([], 100) == 100),
+        assert(applyListSlashes(list1, 100) == 0),
+        assert(applyListSlashes(list2, 100) == 0),
+        assert(applyListSlashes(list3, 100) == -100)
+      }
+    }
+
 
     /*
     * The test testDelegate is a unitest-like test for the delegate function.
@@ -520,6 +538,24 @@ module namada {
         .then(actionUnbond(user, validator, 5))
         .then(actionWithdraw(user, validator))
         .then(all{ assert(delegators.get(user).balance == 12), allUnchanged})
+      }
+    }
+
+    run fullExecutionTest = {
+      nondet user = USERS.oneOf()
+      nondet validator = VALIDATORS.oneOf()
+      all {
+        init
+        .then(actionDelegate(user, validator, 10))
+        .then(actionEvidence(3, validator))
+        .then(actionUnbond(user, validator, 5))
+        .then(actionDelegate(user, validator, 1))
+        .then(actionDelegate(user, validator, 1))
+        .then(actionDelegate(user, validator, 1))
+        .then(actionWithdraw(user, validator))
+        // the 5 tokens unbonded shoul be slashed
+        .then(all{ assert(delegators.get(user).balance == 7), allUnchanged})
+        
       }
     }
 }

--- a/2023/Q2/artifacts/PoS-quint/namada.qnt
+++ b/2023/Q2/artifacts/PoS-quint/namada.qnt
@@ -40,8 +40,11 @@ module namada {
 
     // Slash record
     type Slash = {
+      // Misbehaving epoch
       epoch: epoch,
+      // Misbehaving validator
       validator: Address,
+      // slash rate
       rate: int
     }
 
@@ -103,24 +106,24 @@ module namada {
     // Users initial balances
     pure val INIT_BALANCE = 20
 
-    // set of all user addresses
+    // Set of all user addresses
     pure val USERS = Set("alice", "bob")
 
-    // set of all validator addresses
+    // Set of all validator addresses
     pure val VALIDATORS = Set("alice")
 
-    // transactions per epoch
+    // Transactions per epoch
     // the spec is not fully ready to handle multiple txs per epoch
     // we would need to handle duplicate bonds and unbonds
     pure val TXS_EPOCH = 1
 
-    // unbonding offset
+    // Unbonding offset
     pure val UNBONDING_OFFSET = 2
 
-    // pipeline offset
+    // Pipeline offset
     pure val PIPELINE_OFFSET = 1
 
-    // cubic offset
+    // Cubic offset
     pure val CUBIC_OFFSET = 1
 
     /* ****************************************************************************
@@ -143,7 +146,7 @@ module namada {
 
     // Used to guarantee every step produces a state transition
     // IMPORTANT: Set to false for tests
-    pure val enforceStateTransition = false
+    pure val enforceStateTransition = true
 
     // Last transaction executed by step.
     // Amount is over used by the actions:
@@ -153,46 +156,14 @@ module namada {
     var lastTx: {tag: str, result: bool, user: Address, validator: Address, amount: int}
 
     /**************************************************************************
-    * Helper functions
-    * ************************************************************************* */
-
-    pure def unbondBond(acc: {remainder: int, toRemove: Set[Bond], new: Bond}, bond: Bond): {remainder: int, toRemove: Set[Bond], new: Bond} = 
-      val amountUnbonded = min(bond.amount, acc.remainder)
-      {remainder: acc.remainder - amountUnbonded,
-       toRemove: acc.toRemove.setAdd(bond),
-       new: if (bond.amount > acc.remainder) {start: bond.start, amount: bond.amount - acc.remainder} else acc.new}
-
-    pure def iterateBondsUpToAmount(bonds: Set[Bond], amount: int): {toRemove: Set[Bond], new: Bond} = {
-      val result = bonds.fold({remainder: amount, toRemove: Set(), new: {start: -1, amount: 0}},
-                              (acc, bond) => if (acc.remainder == 0) acc else unbondBond(acc, bond))
-      {toRemove: result.toRemove, new: result.new}
-    }
-
-    pure def computeSlashableAmount(slash: Slash, initAmount: int, computedSlashes: Epoch -> int): int = {
-      val updatedAmount = computedSlashes.keys().filter(x => x + UNBONDING_OFFSET < slash.epoch)
-                                                .fold(initAmount, (acc, e) => acc - computedSlashes.get(e))
-      updatedAmount*slash.rate
-    }
-
-    pure def applyListSlashes(listSlashes: List[Slash], amount: int): int = {
-
-      listSlashes.foldl({finalAmount: amount, computedSlashes: Map()}, (acc, slash) => val slashAmount = computeSlashableAmount(slash, amount, acc.computedSlashes)
-                                                                                       {finalAmount: acc.finalAmount - slashAmount,
-                                                                                        computedSlashes: acc.computedSlashes.safeSet(slash.epoch, slashAmount)}).finalAmount
-    }
-
-    /**************************************************************************
     * Main functions
     * ************************************************************************* */
 
-
-    /*
-    * The function delegate is called when a user wants to delegate tokens to a validator.
-    * 1. First it checks that the user has enough tokens in its account.
-    * 2. Then it locks those tokens by transferring then from the user's account to the PoS special account.
-    * 3. It records that the user has delegated amount tokens to the validator.
-    * 4. It increases the validator's stake.
-    */
+    // The function delegate is called when a user wants to delegate tokens to a validator.
+    // 1. It first checks that the user has enough tokens in its account.
+    // 2. Then it locks those tokens by transferring them from the user's account to the PoS special account.
+    // 3. It records that the user has delegated amount tokens to the validator by creating a bond record.
+    // 4. It increases the validator's stake at the PIPELINE_OFFSET.
     pure def delegate(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState, amount: int): ResultTx = {
       if (amount <= delegatorState.balance and amount > 0) {
         val updatedDelegatorState = delegatorState.with("balance", delegatorState.balance - amount)
@@ -207,28 +178,91 @@ module namada {
       }
     }
 
-    /*
-    * The function unbond is called when a user wants to unbond tokens from a validator.
-    * 1. First it checks that the user has enough tokens bonded to the validator.
-    * 2. Then it records that amount of tokens is unbonded by subtracting amount from bonded and adding to unbonded.
-    * 3. Finally, it decreases the validator's stake.
-    */
+    // The function unbonds a bond record contraint to a maximum amount (acc.remainder).
+    // - @param acc a record with three fields:
+    //   - remainder: the maximum amount of tokens to be unbonded.
+    //   - toRemove: a set of bond records which includes the set of bond records that have been unbonded so far.
+    //   - new: a bond record with start epoch equal to -1.
+    // - @param bond the bond record to be unbonded by the function.
+    // - @returns an update acc record: subtracts the minimum between bond.amount and acc.remainder from acc.remainder; adds the bond to acc.toRemove;
+    // and if bond.amount if gretaer than acc.remainder (meaning that the bond is only partially unbonded), creates a new bond record in acc.new
+    // of bond.amount - acc.remainder tokens.
+    pure def unbondBond(acc: {remainder: int, toRemove: Set[Bond], new: Bond}, bond: Bond): {remainder: int, toRemove: Set[Bond], new: Bond} = 
+      val amountUnbonded = min(bond.amount, acc.remainder)
+      {remainder: acc.remainder - amountUnbonded,
+       toRemove: acc.toRemove.setAdd(bond),
+       new: if (bond.amount > acc.remainder) {start: bond.start, amount: bond.amount - acc.remainder} else acc.new}
+
+    // It iterates over a set of bond records until a given amount of tokens is unbonded. For each iterated bond,
+    // the function calls unbondBond while there are still tokens to be unbonded.
+    // - @param bonds a set a bond records that can be unbonded.
+    // - @param amount the amount of tokens that have to be unbonded.
+    // - @returns a record with two fields: toRemove a set of bond records that have been unbonded and new a bond record
+    //   that either contains a bond record if a bond has been partially unbonded or a bond record with start epoch equal to -1
+    //   otherwise.
+    pure def iterateBondsUpToAmount(bonds: Set[Bond], amount: int): {toRemove: Set[Bond], new: Bond} = {
+      val result = bonds.fold({remainder: amount, toRemove: Set(), new: {start: -1, amount: 0}},
+                              (acc, bond) => if (acc.remainder == 0) acc else unbondBond(acc, bond))
+      {toRemove: result.toRemove, new: result.new}
+    }
+
+    // Computes how much remains from an amount of tokens after applying a slash given that a set of slashes may have been
+    // previously applied.
+    // - @param slash the slash record to be applied.
+    // - @param initAmount the tokens to be slashed.
+    // - @param computeSlashes a map from misbehaving epoch to already applied.
+    // - @returns an integer with the amount that remains after applying slash constraint to computeSlashes.
+    pure def computeSlashableAmount(slash: Slash, initAmount: int, computedSlashes: Epoch -> int): int = {
+      val updatedAmount = computedSlashes.keys().filter(x => x + UNBONDING_OFFSET < slash.epoch)
+                                                .fold(initAmount, (acc, e) => acc - computedSlashes.get(e))
+      updatedAmount*slash.rate
+    }
+
+    // Computes how much remains from an amount of tokens after applying a list of slashes.
+    // - @param listSlashes a list of slashes ordered by misbehaving epoch.
+    // - @param amount the tokens to be slashed.
+    // - @returns an integer with the amount that remains after applying the list of slashes.
+    pure def applyListSlashes(listSlashes: List[Slash], amount: int): int = {
+
+      listSlashes.foldl({finalAmount: amount, computedSlashes: Map()}, (acc, slash) => val slashAmount = computeSlashableAmount(slash, amount, acc.computedSlashes)
+                                                                                       {finalAmount: acc.finalAmount - slashAmount,
+                                                                                        computedSlashes: acc.computedSlashes.safeSet(slash.epoch, slashAmount)}).finalAmount
+    }
+
+    // The function unbond is called when a user wants to unbond tokens from a validator.
+    // 1. It first checks that the user has enough tokens bonded to the validator and that the validator is not frozen.
+    // 2. Then it uses iterateBondsUpToAmount to compute the set of bonds that must be unbonded.
+    // 3. It computes the set of unbond records to be added to the delegators unbonded variable.
+    // 4. It updates the delegator state by removing the unbonded bonds and adding the newly computed unbonds.
+    // 5. It applies any slashes to the unbonded bonds and stroes it in amountAfterSlashing.
+    // 6. It updates the validator's totalUnbonded.
+    // 7. It finally updates the validator's stale at the PIPELINE_OFFSET by subtracting amountAfterSlashing.
+
     pure def unbond(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState, amount: int): ResultTx = {
       val totalBonded = delegatorState.bonded.get(validatorState.address).fold(0, (sum, elem) => sum + elem.amount)      
       if (amount < totalBonded and validatorState.frozen < posState.epoch) {
+        // Compute the epoch at which the unbonded bonds will be withdrawable
         val endEpoch = posState.epoch + PIPELINE_OFFSET + UNBONDING_OFFSET
+        // Compute the set of bonds to be unbonded
         val resultUnbonding = iterateBondsUpToAmount(delegatorState.bonded.get(validatorState.address), amount)
+        // Compute the set of unbond records that have to be recorded out of the set of unbonded bonds computed at the previous step
         val newUnbonds = resultUnbonding.toRemove.map(bond => if (bond.start == resultUnbonding.new.start) {start: bond.start, end: endEpoch, amount: bond.amount -  resultUnbonding.new.amount}
                                                               else {start: bond.start, end: endEpoch, amount: bond.amount})
+        // Compute the updated delegators bonded variable by removing the unbonded bonds and adding a new bond in case one was partially unbonded                                                     
         val updatedBonded = delegatorState.bonded.set(validatorState.address,
                                                       if (resultUnbonding.new.start == -1) delegatorState.bonded.get(validatorState.address).exclude(resultUnbonding.toRemove)
                                                       else delegatorState.bonded.get(validatorState.address).exclude(resultUnbonding.toRemove).union(Set(resultUnbonding.new)))                                                         
+        // Compute the updated delegator's state
         val updatedDelegatorState = delegatorState.with("bonded", updatedBonded)
                                                   .with("unbonded", delegatorState.unbonded.set(validatorState.address, delegatorState.unbonded.get(validatorState.address).union(newUnbonds)))                                  
+        // Compute how much out of amount has not been already removed from the validator's stake when slashing validators
+        // at the end of previous epochs by leveraging applyListSlashes
         val amountAfterSlashing = newUnbonds.fold(0, (sum, element) => val listSlashes = validatorState.slashes.select(slash => element.start <= slash.epoch)
                                                                        sum + applyListSlashes(listSlashes, element.amount))
+        // Compute the updated validator's totalUnbonded variable
         val updatedTotalUnbonded = newUnbonds.fold(validatorState.totalUnbonded.get(posState.epoch + PIPELINE_OFFSET),
                                                    (acc, element) => acc.safeSet(element.start, acc.getOrElse(element.start, 0) + element.amount))
+        // Compute the updated validator's state by updating its state and totalUnbonded.
         val updatedValidatorState = validatorState.with("stake", validatorState.stake.set(posState.epoch + PIPELINE_OFFSET,
                                                                                           validatorState.stake.get(posState.epoch + PIPELINE_OFFSET) - amountAfterSlashing))
                                                   .with("totalUnbonded", validatorState.totalUnbonded.set(posState.epoch + PIPELINE_OFFSET, updatedTotalUnbonded))
@@ -238,12 +272,10 @@ module namada {
       }
     }
 
-    /*
-    * The function withdraw is called when a user wants to withdraw tokens from a validator.
-    * 1. First it computes the amount of tokens that can be withdrawn and returns an error in case there are none.
-    * 2. Then records that those tokens are withdrawn by removing the withdrawable unbond records from unbonded.
-    * 3. Finally, it unlocks the tokens by transferring them from the PoS special account to the user's account.
-    */
+    // The function withdraw is called when a user wants to withdraw tokens from a validator.
+    // 1. First it computes the amount of tokens that can be withdrawn and returns an error in case there are none.
+    // 2. Then records that those tokens are withdrawn by removing the withdrawable unbond records from unbonded.
+    // 3. Finally, it unlocks the tokens by transferring them from the PoS special account to the user's account.
     pure def withdraw(delegatorState: DelegatorState, validatorState: ValidatorState, posState: PosState): ResultTx = {
       // Filter the the set of unbonds that can be withdrawn
       val setWithdrawn = delegatorState.unbonded.get(validatorState.address).filter(element => element.end <= posState.epoch)
@@ -266,11 +298,19 @@ module namada {
       }
     }
 
+    // Computes the total amount of tokens unbonded by a validator that were contributing to the validator's stake when this misbehaved at
+    // a previous epoch, after applying a set of slashes that were potentially processed before the misbehaving epoch.
+    // - @param slash the slash record.
+    // - @param prevSlashes a list of slash records ordered by misbehaving epoch that were protentially processed before slash.epoch.
+    // - @param totalUnbonded a map from epoch to integer.
+    // - @returns an integer with the amount of tokens unbonded.
     pure def computeTotalUnbonded(slash: Slash, prevSlashes: List[Slash], totalUnbonded: Epoch -> int): int = {
       val epochs = totalUnbonded.keys().filter(e => e <= slash.epoch and totalUnbonded.get(e) > 0)
       epochs.fold(0, (sum, e) => sum + applyListSlashes(prevSlashes.select(s => e <= s.epoch and s.epoch + UNBONDING_OFFSET < slash.epoch), totalUnbonded.get(e)))
     }
 
+    // Computes for a given validator and a slash how it much should be slashed at all epochs between the current epoch (curEpoch) + 1 and the current epoch + 1 + 
+    // PIPELINE_OFFSET, accounting for any tokens already unbonded.
     pure def slashValidator(initMap: Epoch -> int, curEpoch: Epoch, stake: int, slash: Slash, prevSlashes: List[Slash], totalUnbonded: Epoch -> Epoch -> int, finalRate: int): Epoch -> int = {
       val initTotalUnbonded = (slash.epoch+1).to(curEpoch).fold(0, (sum, e) => sum + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e)))
       val result = (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).fold((initTotalUnbonded, initMap), (acc, e) => val updatedTotalUnbonded = acc._1 + computeTotalUnbonded(slash, prevSlashes, totalUnbonded.get(e))
@@ -279,10 +319,22 @@ module namada {
       result._2
     }
 
+    // Computes a slash rate based on a set of slashes
+    // - @param setSlashes a set of slashes
+    // - @returns an integer represting the slash rate
     pure def computeFinalRate(setSlashes: Set[Slash]): int = {
       1
     } 
 
+    // This function is executed at the end of an epoch.
+    // 1. It first computes the final rate for all slashes scheduled to be processed at the end of the current epoch.
+    // 2. It computes for each validator how much it should be slashed based of the slashes scheduled to be processed. It already computes 
+    // how much should be substracted from each validator's stake variable at every epoch between the current epoch and the current epoch + PIPELINE_OFFSET.
+    // 3. It updates the validators' state by (i) shifting the epoched stake variable and applying any precomputed slash; (ii) shifting totalUnbonded;
+    // and (iii) appending newly created slash records.
+    // 4. It computes how much has been slashed in total and stores it in totalAmountSlashed.
+    // 5. It update PoS state by increasing the epoch, setting counterTxs to zero, transferring totalAmountSlashed from the PoS accoun tot the slash pool
+    // and shifting equeued slashes.
     pure def endOfEpoch(validatorsState: Address -> ValidatorState, posState: PosState, curEpoch: Epoch): {validatorsState: Address -> ValidatorState, posState: PosState} = {
       val finalRate = computeFinalRate(posState.enqueuedSlashes.get(curEpoch-1).union(posState.enqueuedSlashes.get(curEpoch))
                                                                                .union(posState.enqueuedSlashes.get(curEpoch+1)))
@@ -310,6 +362,11 @@ module namada {
       {validatorsState: updatedValidators, posState: updatedPos}                                                                                                                             
     }
 
+    // The function proccessEvidence is called when a validator misbehaves.
+    // 1. It first creates a slash record.
+    // 2. Then it updates the validator's state by freezing the validator.
+    // 3. It finally enqueues the slash and schedules it to be proccessed at the end of the epoch resulting from adding UNBONDING_OFFSET
+    // to the misbehaving epoch. 
     pure def proccessEvidence(e: Epoch, validatorState: ValidatorState, posState: PosState): {validatorState: ValidatorState, posState: PosState} = {
       val slash = {epoch: e, validator: validatorState.address, rate: 1}
       {validatorState: validatorState.with("frozen", max(validatorState.frozen, e + UNBONDING_OFFSET)),
@@ -324,7 +381,7 @@ module namada {
     /*
     * The action commonTxAfter is called after a transaction is executed.
     * 1. It first checks if it is the last transaction of the current epoch.
-    * 2. If it is the last transaction of the epoch, it calls the endOfEpoch.
+    * 2. If it is the last transaction of the epoch, it calls the endOfEpoch function.
     * 3. Otherwise, it updates the variables using the result of the transaciton and increases counterTxs.
     */
 
@@ -474,8 +531,11 @@ module namada {
 
     /*
     * Execution of the state machine.
-    * 1. Pick a random amount from 0 to MAX_UINT, a user and a validator
-    * 2. Execute one of the actions: delegate, unbond or withdraw.
+    * 1. Pick a random amount from 0 to MAX_UINT, a user, a validator, and an epoch between
+    *    the current epoch and the current epoch - UNBONDING_OFFSET
+    * 2. Execute one of the actions: delegate, unbond, withdraw or evidence.
+    * 3. In case none of the above actions are executable, it executes the advanceEpoch action.
+    * 4. The above logic is implemented by the precondition in actionAdvanceEpoch.
     */
     action step: bool = {
         nondet user = USERS.oneOf()
@@ -489,9 +549,12 @@ module namada {
             actionWithdraw(user, validator),
             actionEvidence(e, validator),
             actionAdvanceEpoch(user, validator, amount, e)
-            //allUnchanged
         }
     }
+
+    /* ****************************************************************************
+    * Tests
+    * ************************************************************************* */
 
     run applyListSlashesTest = {
       val initEpoch = 2

--- a/2023/Q2/artifacts/PoS-quint/namada.qnt
+++ b/2023/Q2/artifacts/PoS-quint/namada.qnt
@@ -312,7 +312,7 @@ module namada {
     * The action commonTxAfter is called after a transaction is executed.
     * 1. It first checks if it is the last transaction of the current epoch.
     * 2. If it is the last transaction of the epoch, it calls the endOfEpoch.
-    * 3. Otherwise, it updates the variables using the result of the transaciton.
+    * 3. Otherwise, it updates the variables using the result of the transaciton and increases counterTxs.
     */
 
     action commonTxAfter(user: Address, validator: Address, result: ResultTx): bool = all {
@@ -360,7 +360,6 @@ module namada {
     }
 
     action actionEvidence(e: Epoch, validator: Address): bool = all {
-      //if (limitEvidence) require(validators.get(validator).frozen < e) else true,
       require(limitEvidence implies validators.get(validator).frozen < e),
       val result = proccessEvidence(e, validators.get(validator), pos)
       all {
@@ -368,6 +367,18 @@ module namada {
         pos' = result.posState,
         delegators' = delegators,
         lastTx' = {tag: "Evidence", result: true, user: "", validator: validator, amount: e}
+      }
+    }
+
+    action actionAdvanceEpoch(user: Address, validator: Address, amount: int, e: Epoch): bool = all {
+      require(delegate(delegators.get(user), validators.get(validator), pos, amount).success == false and
+              unbond(delegators.get(user), validators.get(validator), pos, amount).success == false and
+              withdraw(delegators.get(user), validators.get(validator), pos).success == false and
+              limitEvidence implies validators.get(validator).frozen >= e),
+      val result = {success: true, delegatorState: delegators.get(user), validatorState: validators.get(validator), posState: pos}
+      all {
+        commonTxAfter(user, validator, result),
+        lastTx' = {tag: "Advance", result: result.success, user: user, validator: validator, amount: 0}
       }
     }
 
@@ -464,7 +475,8 @@ module namada {
             actionDelegate(user, validator, amount),
             actionUnbond(user, validator, amount),
             actionWithdraw(user, validator),
-            actionEvidence(e, validator)
+            actionEvidence(e, validator),
+            actionAdvanceEpoch(user, validator, amount, e)
             //allUnchanged
         }
     }


### PR DESCRIPTION
This PR includes a Quint spec of Namada's PoS without redelegation. It does not model validator's transactions and assumes that the set of validators and users is fixed. It is a less restrictive model that the one specified in TLA+. Includes:
- Comments
- Invariants
- Tests
- Execution environment for simulations