### PR TITLE
Add deterministic iteration over validator addresses

### DIFF
--- a/2023/Q3/artifacts/PoS-quint/extraSpells.qnt
+++ b/2023/Q3/artifacts/PoS-quint/extraSpells.qnt
@@ -50,6 +50,26 @@ module extraSpells {
     assert(maxSet(Set(-8, -4, -3)) == -3),
   }
 
+    /// Compute the min of a set of integers.
+  /// The set must be non-empty
+  ///
+  /// - @param __set a set of integers
+  /// - @returns the min
+  pure def minSet(__set: Set[int]): int = {
+    __set.fold((true, 0), (__min, __i) => if (__min._1) (false, __i)
+                                          else if (__i < __min._2) (false, __i) else (false, __min._2))._2
+  }
+
+  run minSetTest = all {
+    assert(minSet(Set(3, 4, 8)) == 3),
+    assert(minSet(Set(3, 8, 4)) == 3),
+    assert(minSet(Set(8, 4, 3)) == 3),
+    assert(minSet(Set(8, 8, 8)) == 8),
+    assert(minSet(Set(-3, -4, -8)) == -8),
+    assert(minSet(Set(-3, -8, -4)) == -8),
+    assert(minSet(Set(-8, -4, -3)) == -8),
+  }
+
   /// Orders a set of integers in decreasing order.
   ///
   /// - @param __set a set of integers
@@ -64,6 +84,22 @@ module extraSpells {
     assert(sortSetDecreasing(Set(8, 4, 3)) == [8, 4, 3]),
     assert(sortSetDecreasing(Set()) == []),
     assert(sortSetDecreasing(Set(9, -2, 5, 10)) == [10, 9, 5, -2]),
+  }
+
+  /// Orders a set of integers in increasing order.
+  ///
+  /// - @param __set a set of integers
+  /// - @returns a list with the integers ordered in increasing order
+  pure def sortSetIncreasing(__set: Set[int]): List[int] = {
+    __set.fold({unordered: __set, ordered: List()}, (acc, _) => val __max = minSet(acc.unordered)
+                                                    {unordered: acc.unordered.setRemove(__max), ordered: acc.ordered.append(__max)}).ordered
+  }
+
+  run sortSetIncreasingTest = all {
+    assert(sortSetIncreasing(Set(3, 8, 4)) == [3, 4, 8]),
+    assert(sortSetIncreasing(Set(8, 4, 3)) == [3, 4, 8]),
+    assert(sortSetIncreasing(Set()) == []),
+    assert(sortSetIncreasing(Set(9, -2, 5, 10)) == [-2, 5, 9, 10]),
   }
 
   /// Add a set element.

--- a/2023/Q3/artifacts/PoS-quint/helper-functions.qnt
+++ b/2023/Q3/artifacts/PoS-quint/helper-functions.qnt
@@ -724,7 +724,7 @@ module helperFunctions {
 
     // The function computeRemainderRedelegation takes a redelegation record and computes how many tokens are left from the redelegation at the destination validator considering 
     // that the source validator may have misbehaved while the redelegated tokens were contributing to its stake and that some may have unbonded from the destination
-    // validator. The function computes the how muchis left at the destination validator at epochs from curEpoch + 1 to curEpoch + PIPELINE_LENGTH.
+    // validator. The function computes the how much is left at the destination validator at epochs from curEpoch + 1 to curEpoch + PIPELINE_LENGTH.
     // - @param redelegation a Redelegation record.
     // - @param curEpoch the the current epoch.
     // - @param slashes a list of slashes of the source validator.
@@ -736,15 +736,16 @@ module helperFunctions {
                                           slashes: List[Slash],
                                           totalRedelegatedUnbonded: Epoch -> Epoch -> RedelegatedBondsMap,
                                           balanceMap: Epoch -> int): Epoch -> int = {
-      // We should iterate in epoch increasing order. TODO: transform this into a list and use foldl.
-      (redelegation.redBondStart).to(curEpoch+PIPELINE_OFFSET).fold((0, balanceMap), (acc, e) => val updatedTotalUnbonded = if (not(totalRedelegatedUnbonded.get(e).hasRedelegation(redelegation.redBondStart, redelegation.srcValidator, redelegation.bondStart))) acc._1
-                                                                                                                            else acc._1 + totalRedelegatedUnbonded.get(e).get(redelegation.redBondStart).get(redelegation.srcValidator).get(redelegation.bondStart)
-                                                                                                 if (e <= curEpoch) (updatedTotalUnbonded, acc._2)
-                                                                                                 else {
-                                                                                                 val stakeLeft = val listSlashes = slashes.select(s => inRedelegationSlashingWindow(s.epoch, startRedelegationFromEnd(redelegation.redBondStart), redelegation.redBondStart) and
-                                                                                                                                                       redelegation.bondStart <= s.epoch)
-                                                                                                                 applyListSlashes(listSlashes, redelegation.amount - updatedTotalUnbonded)
-                                                                                                 (updatedTotalUnbonded, acc._2.set(e, acc._2.get(e) + stakeLeft))})._2                                                                                                             
+      // We must iterate in epoch increasing order.
+      val epochRange = range(redelegation.redBondStart, curEpoch+PIPELINE_OFFSET+1)
+      epochRange.foldl((0, balanceMap), (acc, e) => val updatedTotalUnbonded = if (not(totalRedelegatedUnbonded.get(e).hasRedelegation(redelegation.redBondStart, redelegation.srcValidator, redelegation.bondStart))) acc._1
+                                                                               else acc._1 + totalRedelegatedUnbonded.get(e).get(redelegation.redBondStart).get(redelegation.srcValidator).get(redelegation.bondStart)
+                                                    if (e <= curEpoch) (updatedTotalUnbonded, acc._2)
+                                                    else {
+                                                    val stakeLeft = val listSlashes = slashes.select(s => inRedelegationSlashingWindow(s.epoch, startRedelegationFromEnd(redelegation.redBondStart), redelegation.redBondStart) and
+                                                                                                          redelegation.bondStart <= s.epoch)
+                                                                    applyListSlashes(listSlashes, redelegation.amount - updatedTotalUnbonded)
+                                                    (updatedTotalUnbonded, acc._2.set(e, acc._2.get(e) + stakeLeft))})._2                                                                                                             
     }
 
     run computeRemainderRedelegationTest = {
@@ -823,17 +824,18 @@ module helperFunctions {
       val initBalanceBonds = (infractionEpoch+1).to(curEpoch).fold(0, (sum, e) => sum + (totalBonded.get(e) - computeRecentTotalUnbonded(infractionEpoch, totalUnbonded.get(e), totalRedelegatedUnbonded.get(e))))
       val zeroedBalanceRedelegatedBonds = (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).mapBy(e => 0)
       val initBalanceRedelegatedBonds = (infractionEpoch+1).to(curEpoch).fold(zeroedBalanceRedelegatedBonds, (acc, e) => computeBalanceRedelegatedBonds(totalRedelegatedBonded.get(e), e, curEpoch, slashes, totalRedelegatedUnbonded, acc))
-      // We should iterate in epoch increasing order. TODO: transform this into a list and use foldl.
-      val result = (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).fold((initTotalUnbonded,
-                                                                   initBalanceBonds,
-                                                                   initBalanceRedelegatedBonds,
-                                                                   slashedAmountsMap), (acc, e) => val updatedTotalUnbonded = acc._1 + computeTotalUnbonded(validator, infractionEpoch, slashes, totalUnbonded.get(e), totalRedelegatedUnbonded.get(e))
-                                                                                                   val updatedBalanceBonds = acc._2 + (totalBonded.get(e) - computeRecentTotalUnbonded(infractionEpoch, totalUnbonded.get(e), totalRedelegatedUnbonded.get(e)))
-                                                                                                   val updatedBalanceRedelegatedBonds = computeBalanceRedelegatedBonds(totalRedelegatedBonded.get(e), e, curEpoch, slashes, totalRedelegatedUnbonded, acc._3)
-                                                                                                   val slashedAmount = (infractionStake - updatedTotalUnbonded) * finalRate
-                                                                                                   val currentStake = stakes.get(e) - acc._4.get(e)
-                                                                                                   val slashableStake = (currentStake - updatedBalanceBonds - updatedBalanceRedelegatedBonds.get(e))
-                                                                                                   (updatedTotalUnbonded, updatedBalanceBonds, updatedBalanceRedelegatedBonds, acc._4.set(e, acc._4.get(e) + min(slashedAmount, slashableStake))))
+      // We must iterate in epoch increasing order.
+      val epochRange = range(curEpoch+1, curEpoch+PIPELINE_OFFSET+1)
+      val result = epochRange.foldl((initTotalUnbonded,
+                                     initBalanceBonds,
+                                     initBalanceRedelegatedBonds,
+                                     slashedAmountsMap), (acc, e) => val updatedTotalUnbonded = acc._1 + computeTotalUnbonded(validator, infractionEpoch, slashes, totalUnbonded.get(e), totalRedelegatedUnbonded.get(e))
+                                                                     val updatedBalanceBonds = acc._2 + (totalBonded.get(e) - computeRecentTotalUnbonded(infractionEpoch, totalUnbonded.get(e), totalRedelegatedUnbonded.get(e)))
+                                                                     val updatedBalanceRedelegatedBonds = computeBalanceRedelegatedBonds(totalRedelegatedBonded.get(e), e, curEpoch, slashes, totalRedelegatedUnbonded, acc._3)
+                                                                     val slashedAmount = (infractionStake - updatedTotalUnbonded) * finalRate
+                                                                     val currentStake = stakes.get(e) - acc._4.get(e)
+                                                                     val slashableStake = (currentStake - updatedBalanceBonds - updatedBalanceRedelegatedBonds.get(e))
+                                                                     (updatedTotalUnbonded, updatedBalanceBonds, updatedBalanceRedelegatedBonds, acc._4.set(e, acc._4.get(e) + min(slashedAmount, slashableStake))))
       result._4
     }
 
@@ -984,17 +986,18 @@ module helperFunctions {
       val infractionEpoch = curEpoch - slashProcessingDelay
       val initTotalUnbonded = (infractionEpoch+1).to(curEpoch).fold(0, (sum, e) => if (not(totalRedelegatedUnbonded.get(e).hasRedelegation(redBondStart, srcValidator, bondStart))) sum
                                                                                    else sum + totalRedelegatedUnbonded.get(e).get(redBondStart).get(srcValidator).get(bondStart))
-      // We should iterate in epoch increasing order. TODO: transform this into a list and use foldl.
-      val result = (curEpoch+1).to(curEpoch+PIPELINE_OFFSET).fold((initTotalUnbonded, slashedAmountsMap), (acc, e) => val updatedTotalUnbonded = if (not(totalRedelegatedUnbonded.get(e).hasRedelegation(redBondStart, srcValidator, bondStart))) acc._1
-                                                                                                                                                 else acc._1 + totalRedelegatedUnbonded.get(e).get(redBondStart).get(srcValidator).get(bondStart)
-                                                                                                                      val slashAmount = val listSlashes = slashes.select(s => inRedelegationSlashingWindow(s.epoch, startRedelegationFromEnd(redBondStart), redBondStart) and
-                                                                                                                                                                              s.epoch + slashProcessingDelay < infractionEpoch and
-                                                                                                                                                                              bondStart <= s.epoch)
-                                                                                                                                        applyListSlashes(listSlashes, amount - updatedTotalUnbonded) * finalRate
-                                                                                                                      val slashableStake = val listSlashes = slashes.select(s => inRedelegationSlashingWindow(s.epoch, startRedelegationFromEnd(redBondStart), redBondStart) and
-                                                                                                                                                                                 bondStart <= s.epoch)
-                                                                                                                                           applyListSlashes(listSlashes, amount - updatedTotalUnbonded)
-                                                                                                                      (updatedTotalUnbonded, acc._2.set(e, acc._2.get(e) + min(slashAmount, slashableStake))))
+      // We must iterate in epoch increasing order.
+      val epochRange = range(curEpoch+1, curEpoch+PIPELINE_OFFSET+1)
+      val result = epochRange.foldl((initTotalUnbonded, slashedAmountsMap), (acc, e) => val updatedTotalUnbonded = if (not(totalRedelegatedUnbonded.get(e).hasRedelegation(redBondStart, srcValidator, bondStart))) acc._1
+                                                                                                                   else acc._1 + totalRedelegatedUnbonded.get(e).get(redBondStart).get(srcValidator).get(bondStart)
+                                                                                        val slashAmount = val listSlashes = slashes.select(s => inRedelegationSlashingWindow(s.epoch, startRedelegationFromEnd(redBondStart), redBondStart) and
+                                                                                                                                                s.epoch + slashProcessingDelay < infractionEpoch and
+                                                                                                                                                bondStart <= s.epoch)
+                                                                                                          applyListSlashes(listSlashes, amount - updatedTotalUnbonded) * finalRate
+                                                                                        val slashableStake = val listSlashes = slashes.select(s => inRedelegationSlashingWindow(s.epoch, startRedelegationFromEnd(redBondStart), redBondStart) and
+                                                                                                                                                   bondStart <= s.epoch)
+                                                                                                             applyListSlashes(listSlashes, amount - updatedTotalUnbonded)
+                                                                                        (updatedTotalUnbonded, acc._2.set(e, acc._2.get(e) + min(slashAmount, slashableStake))))
       result._2                                                                                                                                  
     }
 

--- a/2023/Q3/artifacts/PoS-quint/helper-functions.qnt
+++ b/2023/Q3/artifacts/PoS-quint/helper-functions.qnt
@@ -99,6 +99,47 @@ module helperFunctions {
       }
     }
 
+  /// Orders a set of validators addresses in decreasing order.
+  ///
+  /// - @param __set a set of validator addresses.
+  /// - @param __rank a map from validator addresse to rank (int).
+  /// - @returns a list with the validator addresses ordered in decreasing order
+  pure def sortValidatorsDecreasing(__set: Set[Address], __rank: Address -> int): List[Address] = {
+    __set.fold({unordered: __set, ordered: List()}, (acc, _) => val __max = maxValidator(acc.unordered, __rank)
+                                                    {unordered: acc.unordered.setRemove(__max), ordered: acc.ordered.append(__max)}).ordered
+  }
+
+  run sortValidatorsDecreasingTest = all {
+    val __rank = Map("alice" -> 1, "bob" -> 2, "john" -> 4)
+    all {
+      assert(sortValidatorsDecreasing(Set("alice", "bob", "john"), __rank) == List("john", "bob", "alice")),
+      assert(sortValidatorsDecreasing(Set("alice", "bob", "john"), __rank) == List("john", "bob", "alice")),
+      assert(sortValidatorsDecreasing(Set("alice", "john", "bob"), __rank) == List("john", "bob", "alice")),
+      assert(sortValidatorsDecreasing(Set("john", "bob", "alice"), __rank) == List("john", "bob", "alice")),
+      assert(sortValidatorsDecreasing(Set(), __rank) == List()),
+    }
+  }
+  /// Compute the max of a set of validator addresses according to a rank map.
+  ///
+  /// - @param __set a set of validator addresses.
+  /// - @param __rank a map from validator addresse to rank (int).
+  /// - @returns the max.
+  pure def maxValidator(__set: Set[Address], __rank: Address -> int): Address = {
+     __set.fold((true, ""), (__max, __i) => if (__max._1) (false, __i)
+                                           else if (__rank.get(__i) > __rank.get(__max._2)) (false, __i) else (false, __max._2))._2
+  }
+
+  run maxValidatorTest = all {
+    val __rank = Map("alice" -> 1, "bob" -> 2, "john" -> 4)
+    all {
+      assert(maxValidator(Set("alice", "bob", "john"), __rank) == "john"),
+      assert(maxValidator(Set("alice", "bob", "john"), __rank) == "john"),
+      assert(maxValidator(Set("alice", "john", "bob"), __rank) == "john"),
+      assert(maxValidator(Set("john", "bob", "alice"), __rank) == "john"),
+      assert(maxValidator(Set(), __rank) == ""),
+    }
+  }
+
     // **************************************************************************
     // Redelegation helper functions
     // ************************************************************************* 
@@ -113,37 +154,38 @@ module helperFunctions {
     //   Note that valsToRemove includes valToModify if different to "" and epochsToRemove includes epochToModify if different to -1.
     pure def computeModifiedRedelegation(redelegatedBonds: RedelegatedBondsMap, epoch: Epoch, amount: int): ModifiedRedelegation = {
       val totalRedelegated = redelegatedBonds.keys().fold(0, (sum, src) => redelegatedBonds.get(src).keys().fold(sum, (acc, e) => acc + redelegatedBonds.get(src).get(e)))
+      val orderedValidators = sortValidatorsDecreasing(redelegatedBonds.keys(), VALIDATORS_RANK)
       // If the total amount of redelegated bonds is less than the target amount, then all redelegated bonds must be unbonded.
       if (totalRedelegated <= amount) {epoch: -1, valsToRemove: Set(), valToModify: "", epochsToRemove: Set(), epochToModify: -1, newAmount: -1}
       // If the total amount of redelegated bonds is greater than the target amount, then we need to iterate over the redelegated bonds
       // until the target amount is unbonded. The iteration works as follows (comments interleaved with the folds):
-      // 1. It first iterates over source validators. We should iterate in a deterministic order over validators here. Do not know how to do it in Quint at the moment.
-      else redelegatedBonds.keys().fold({remainder: amount, modified: {epoch: epoch, valsToRemove: Set(), valToModify: "", epochsToRemove: Set(), epochToModify: -1, newAmount: -1}}, 
-                                        (acc, src) => if (acc.remainder == 0) acc
-                                                      else {
-                                                        val totalSrcValidator = redelegatedBonds.get(src).keys().fold(0, (sum, e) => sum + redelegatedBonds.get(src).get(e))
-                                                        // 2. For a given validator, if the remaining is greater or equal to the total amount of redelegated tokens of that source validator, the
-                                                        //   function removes the source validator: all its redelegated tokens will be  effectively unbonded.
-                                                        if (totalRedelegated <= acc.remainder) {remainder: acc.remainder - totalSrcValidator,
-                                                                                                modified: acc.modified.with("valsToRemove", acc.modified.valsToRemove.setAdd(src))}
-                                                        else {
-                                                          // 3. If the remaining is less than the total amount of redelegated tokens of that source validator, the function iterates over all the bonds
-                                                          //   of that validator in epoch decreasing order until the remaining is unbonded.
-                                                          val resultIteration = iterateBondsUpToAmount(redelegatedBonds.get(src), acc.remainder)
-                                                          {remainder: 0,
-                                                          modified: if (resultIteration.new.start == -1) acc.modified.with("valsToRemove", acc.modified.valsToRemove.setAdd(src))
-                                                                                                                     .with("valToModify", src)
-                                                                                                                     .with("epochsToRemove", resultIteration.toRemove)
-                                                                    else acc.modified.with("valsToRemove", acc.modified.valsToRemove.setAdd(src))
-                                                                                     .with("valToModify", src)
-                                                                                     .with("epochsToRemove", resultIteration.toRemove.setAdd(resultIteration.new.start))
-                                                                                     .with("epochToModify", resultIteration.new.start)
-                                                                                     .with("newAmount", resultIteration.new.amount)}
-                                                        }
-                                                      }).modified
+      // 1. It first iterates over source validators in a deterministic order (ranking decreasing order)
+      else orderedValidators.foldl({remainder: amount, modified: {epoch: epoch, valsToRemove: Set(), valToModify: "", epochsToRemove: Set(), epochToModify: -1, newAmount: -1}}, 
+                                   (acc, src) => if (acc.remainder == 0) acc
+                                                 else {
+                                                   val totalSrcValidator = redelegatedBonds.get(src).keys().fold(0, (sum, e) => sum + redelegatedBonds.get(src).get(e))
+                                                   // 2. For a given validator, if the remaining is greater or equal to the total amount of redelegated tokens of that source validator, the
+                                                   //   function removes the source validator: all its redelegated tokens will be  effectively unbonded.
+                                                   if (totalRedelegated <= acc.remainder) {remainder: acc.remainder - totalSrcValidator,
+                                                                                           modified: acc.modified.with("valsToRemove", acc.modified.valsToRemove.setAdd(src))}
+                                                   else {
+                                                     // 3. If the remaining is less than the total amount of redelegated tokens of that source validator, the function iterates over all the bonds
+                                                     //   of that validator in epoch decreasing order until the remaining is unbonded.
+                                                     val resultIteration = iterateBondsUpToAmount(redelegatedBonds.get(src), acc.remainder)
+                                                     {remainder: 0,
+                                                     modified: if (resultIteration.new.start == -1) acc.modified.with("valsToRemove", acc.modified.valsToRemove.setAdd(src))
+                                                                                                                .with("valToModify", src)
+                                                                                                                .with("epochsToRemove", resultIteration.toRemove)
+                                                               else acc.modified.with("valsToRemove", acc.modified.valsToRemove.setAdd(src))
+                                                                                .with("valToModify", src)
+                                                                                .with("epochsToRemove", resultIteration.toRemove.setAdd(resultIteration.new.start))
+                                                                                .with("epochToModify", resultIteration.new.start)
+                                                                                .with("newAmount", resultIteration.new.amount)}
+                                                  }
+                                                 }).modified
     }
 
-    // TODO: more tests here when we can iterate over srouce validators deterministically
+    // TODO: more tests here now that we iterate over source validators deterministically
     run computeModifiedRedelegationTest = {
       val redelegatedBonds = Map("alice" -> Map(2 -> 6, 4 -> 7), "bob" -> Map(1 -> 5, 4 -> 7))
       all {

--- a/2023/Q3/artifacts/PoS-quint/namada-redelegation.qnt
+++ b/2023/Q3/artifacts/PoS-quint/namada-redelegation.qnt
@@ -564,10 +564,9 @@ module namada {
         init
         .then(actionDelegate(user, validator, 10))
         .then(actionUnbond(user, validator, 5))
-        .then(actionFauxTransaction(user, validator, 0, 0, -1).repeated(UNBONDING_OFFSET+PIPELINE_OFFSET+CUBIC_OFFSET))
+        .then((UNBONDING_OFFSET+PIPELINE_OFFSET+CUBIC_OFFSET).reps(_ => actionFauxTransaction(user, validator, 0, 0, -1)))
         .then(actionWithdraw(user, validator))
         .then(all{ assert(delegators.get(user).balance == 15), allUnchanged})
-        
       }
     }
 
@@ -596,7 +595,7 @@ module namada {
         .then(actionDelegate(user, validator, amount))
         .then(actionUnbond(user, validator, amountUnbonded))//epoch=UNBONDING_OFFSET+1
         .then(actionEvidence(initEpoch + 1, validator))//to be processed at the end of 2*UNBONDING_OFFSET+2*CUBIC_OFFSET+1
-        .then(actionFauxTransaction(user, validator, 0, 0, -1).repeated(UNBONDING_OFFSET+CUBIC_OFFSET))
+        .then((UNBONDING_OFFSET+CUBIC_OFFSET).reps(_ => actionFauxTransaction(user, validator, 0, 0, -1)))
         //slash already processed
         .then(actionWithdraw(user, validator))
         // the 5 tokens unbonded shoul be slashed
@@ -621,7 +620,7 @@ module namada {
         .then(actionDelegate(user, validator, amount)) //epoch=UNBONDING_OFFSET assuming init epoch=UNBONDING_OFFSET
         .then(actionUnbond(user, validator, amountUnbonded))//epoch=UNBONDING_OFFSET+CUBIC_OFFSET+1
         .then(actionEvidence(initEpoch + 1, validator)) //to be processed at the end of 2*UNBONDING_OFFSET+2*CUBIC_OFFSET+1
-        .then(actionFauxTransaction(user, validator, 0, 0, -1).repeated(slashingOffset - 1))//epoch=2*UNBONDING_OFFSET+2*CUBIC_OFFSET
+        .then((slashingOffset - 1).reps(_ => actionFauxTransaction(user, validator, 0, 0, -1)))//epoch=2*UNBONDING_OFFSET+2*CUBIC_OFFSET
         //check that slash has not been processed yet
         .then(all{ assert(validators.get(validator).slashes == List()),
                    allUnchanged })
@@ -710,7 +709,7 @@ module namada {
         .then(actionEvidence(initEpoch + PIPELINE_OFFSET + 1, validator)) // epoch = initEpoch + 6
         //slash processed at initEpoch + PIPELINE_OFFSET + 2 + CUBIC_OFFSET + UNBONDING_OFFSET = (initEpoch + 4) + 5 = initEpoch + 9
         .then(actionEvidence(initEpoch + PIPELINE_OFFSET + 2, validator)) // epoch = initEpoch + 6
-        .then(actionFauxTransaction(user, validator, 0, 0, -1).repeated(3)) // epoch = initEpoch + 6..initEpoch + 8
+        .then(3.reps(_ => actionFauxTransaction(user, validator, 0, 0, -1))) // epoch = initEpoch + 6..initEpoch + 8
         .then(all{assert(validators.get(validator).stake.get(initEpoch + 9) == stakeAfterProcessing),
                   allUnchanged })
       }
@@ -728,13 +727,13 @@ module namada {
         require(size(VALIDATORS) >= 2),
         init
         .then(actionDelegate(user, srcValidator, amountDelegate))
-        .then(actionFauxTransaction(user, srcValidator, 0, 0, -1).repeated(PIPELINE_OFFSET))
+        .then(PIPELINE_OFFSET.reps(_ => actionFauxTransaction(user, srcValidator, 0, 0, -1)))
         .then(actionRedelegate(user, srcValidator, destValidator, amountRedelegate))
         .then(all {assert(delegators.get(user).redelegatedBonded.get(destValidator).get(initEpoch+2*PIPELINE_OFFSET+1).get(srcValidator).get(initEpoch+PIPELINE_OFFSET) == amountRedelegate),
                    assert(validators.get(destValidator).incomingRedelegations.get(user) == initEpoch+2*PIPELINE_OFFSET+1),
                    assert(validators.get(srcValidator).outgoingRedelegations.get(destValidator).get((initEpoch+PIPELINE_OFFSET, initEpoch+PIPELINE_OFFSET+1)) == amountRedelegate),
                    allUnchanged})
-        .then(actionFauxTransaction(user, srcValidator, 0, 0, -1).repeated(PIPELINE_OFFSET))
+        .then(PIPELINE_OFFSET.reps(_ => actionFauxTransaction(user, srcValidator, 0, 0, -1)))
         .then(actionUnbond(user, destValidator, amountUnbond))
         .then(val bondStart = initEpoch+PIPELINE_OFFSET
               val redelegationEnd = bondStart+PIPELINE_OFFSET+1
@@ -744,7 +743,7 @@ module namada {
                    assert(delegators.get(user).redelegatedUnbonded.get(destValidator).get((redelegationEnd, unbondEnd)).get(srcValidator).get(bondStart) == amountUnbond),
                    assert(validators.get(destValidator).totalRedelegatedUnbonded.get(unbondMaterialized).get(redelegationEnd).get(srcValidator).get(bondStart) == amountUnbond),
                    allUnchanged})
-        .then(actionFauxTransaction(user, srcValidator, 0, 0, -1).repeated(CUBIC_OFFSET+UNBONDING_OFFSET+1))
+        .then((CUBIC_OFFSET+UNBONDING_OFFSET+1).reps(_ => actionFauxTransaction(user, srcValidator, 0, 0, -1)))
         .then(actionWithdraw(user, destValidator))
         .then(all {assert(delegators.get(user).redelegatedUnbonded.get(destValidator) == Map()),
                    assert(delegators.get(user).balance == INIT_BALANCE - amountDelegate + amountUnbond),
@@ -763,13 +762,13 @@ module namada {
         require(size(VALIDATORS) >= 2),
         init
         .then(actionDelegate(user, srcValidator, amountDelegate))
-        .then(actionFauxTransaction(user, srcValidator, 0, 0, -1).repeated(PIPELINE_OFFSET))
+        .then(PIPELINE_OFFSET.reps(_ => actionFauxTransaction(user, srcValidator, 0, 0, -1)))
         .then(actionRedelegate(user, srcValidator, destValidator, amountRedelegate))
         .then(all {assert(delegators.get(user).redelegatedBonded.get(destValidator).get(initEpoch+2*PIPELINE_OFFSET+1).get(srcValidator).get(initEpoch+PIPELINE_OFFSET) == amountRedelegate),
                    assert(validators.get(destValidator).incomingRedelegations.get(user) == initEpoch+2*PIPELINE_OFFSET+1),
                    assert(validators.get(srcValidator).outgoingRedelegations.get(destValidator).get((initEpoch+PIPELINE_OFFSET, initEpoch+PIPELINE_OFFSET+1)) == amountRedelegate),
                    allUnchanged})
-        .then(actionFauxTransaction(user, srcValidator, 0, 0, -1).repeated(PIPELINE_OFFSET))
+        .then(PIPELINE_OFFSET.reps(_ => actionFauxTransaction(user, srcValidator, 0, 0, -1)))
         .then(actionUnbond(user, destValidator, amountUnbond))
         //an epoch before the end of the redelegation, i.e., within the redelegation slashing window
         .then(actionEvidence(initEpoch+2*PIPELINE_OFFSET, srcValidator))
@@ -781,7 +780,7 @@ module namada {
                    assert(delegators.get(user).redelegatedUnbonded.get(destValidator).get((redelegationEnd, unbondEnd)).get(srcValidator).get(bondStart) == amountUnbond),
                    assert(validators.get(destValidator).totalRedelegatedUnbonded.get(unbondMaterialized).get(redelegationEnd).get(srcValidator).get(bondStart) == amountUnbond),
                    allUnchanged})
-        .then(actionFauxTransaction(user, srcValidator, 0, 0, -1).repeated(CUBIC_OFFSET+UNBONDING_OFFSET+1))
+        .then((CUBIC_OFFSET+UNBONDING_OFFSET+1).reps(_ => actionFauxTransaction(user, srcValidator, 0, 0, -1)))
         .then(actionWithdraw(user, destValidator))
         .then(all {assert(delegators.get(user).redelegatedUnbonded.get(destValidator) == Map()),
                    assert(delegators.get(user).balance == INIT_BALANCE - amountDelegate),

--- a/2023/Q3/artifacts/PoS-quint/namada-types.qnt
+++ b/2023/Q3/artifacts/PoS-quint/namada-types.qnt
@@ -171,6 +171,9 @@ module types {
   // Set of all validator addresses
   pure val VALIDATORS: Set[str] = Set("alice", "bob")
 
+  // A map from validator address to integer. Used to iterate deterministically over validator addresses
+  pure val VALIDATORS_RANK: Address -> int = Map("alice" -> 1, "bob" -> 2)
+
   // Transactions per epoch
   // the spec is not fully ready to handle multiple txs per epoch
   // we would need to handle duplicate bonds and unbonds


### PR DESCRIPTION
This PR adds deterministic iteration over validator addresses; adds in epoch-increasing order iterations; and migrates to `reps`.